### PR TITLE
Fix APK Release BASENAME in Pipeline

### DIFF
--- a/.github/workflows/APK-Release.yml
+++ b/.github/workflows/APK-Release.yml
@@ -99,7 +99,7 @@ jobs:
       run: |
         cd apk
         for f in *.apk; do
-          BASENAME=`echo ${f}|awk -F '-apk-' '{print $2}'`
+          BASENAME=`echo ${f}|awk -F '-APK-' '{print $2}'`
           mv "${f}" "org.meumeu.wivrn-${BASENAME}"
         done
 


### PR DESCRIPTION
- Update the awk split to work on new repo name WiVRn-APK

This will still fail until we set `DOWNSTREAM_GITHUB_TOKEN` as a repository secrete here: https://github.com/WiVRn/WiVRn-APK/settings/secrets/actions