### PR TITLE
only rely on history if clock_offset is stable

### DIFF
--- a/server/driver/clock_offset.h
+++ b/server/driver/clock_offset.h
@@ -32,13 +32,13 @@ struct clock_offset
 {
 	// y: headset time
 	// x: server time
-	// y = ax+b
+	// y = x+b
 	int64_t b = 0;
-	double a = 1;
+	bool stable = false;
 
 	operator bool() const
 	{
-		return b != 0;
+		return stable;
 	}
 
 	XrTime from_headset(XrTime) const;

--- a/server/driver/history.h
+++ b/server/driver/history.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "clock_offset.h"
+#include "util/u_logging.h"
 #include <algorithm>
 #include <cstddef>
 #include <list>
@@ -47,6 +48,15 @@ protected:
 		// Discard outdated data, packets could be reordered
 		if (not data.empty())
 		{
+			// keep only one sample if the clock_offset is unreliable
+			if (not offset)
+			{
+				U_LOG_D("not using history: clock_offset not stable");
+				data.clear();
+				data.emplace_back(sample, produced, t);
+				return;
+			}
+
 			if (data.back().produced_timestamp > produced)
 				return;
 		}

--- a/server/driver/wivrn_pacer.cpp
+++ b/server/driver/wivrn_pacer.cpp
@@ -68,7 +68,7 @@ void wivrn_pacer::on_feedback(const xrt::drivers::wivrn::from_headset::feedback 
 	    feedback.displayed and
 	    feedback.frame_index == last.frame_index + 1)
 	{
-		frame_duration_ns = std::lerp(frame_duration_ns, (feedback.displayed - last.displayed) / offset.a, 0.1);
+		frame_duration_ns = std::lerp(frame_duration_ns, (feedback.displayed - last.displayed), 0.1);
 	}
 
 	auto blitted = feedback.blitted;

--- a/server/driver/wivrn_session.cpp
+++ b/server/driver/wivrn_session.cpp
@@ -261,8 +261,6 @@ void wivrn_session::operator()(from_headset::tracking && tracking)
 	}
 
 	auto offset = offset_est.get_offset();
-	if (not offset)
-		return;
 
 	hmd->update_tracking(tracking, offset);
 	left_hand->update_tracking(tracking, offset);
@@ -276,8 +274,6 @@ void wivrn_session::operator()(from_headset::tracking && tracking)
 void wivrn_session::operator()(from_headset::hand_tracking && hand_tracking)
 {
 	auto offset = offset_est.get_offset();
-	if (not offset)
-		return;
 
 	left_hand->update_hand_tracking(hand_tracking, offset);
 	right_hand->update_hand_tracking(hand_tracking, offset);
@@ -288,16 +284,13 @@ void wivrn_session::operator()(from_headset::fb_face2 && fb_face2)
 		return;
 
 	auto offset = offset_est.get_offset();
-	if (not offset)
-		return;
 
 	fb_face2_tracker->update_tracking(fb_face2, offset);
 }
 void wivrn_session::operator()(from_headset::inputs && inputs)
 {
 	auto offset = get_offset();
-	if (not offset)
-		return;
+
 	left_hand->set_inputs(inputs, offset);
 	right_hand->set_inputs(inputs, offset);
 }


### PR DESCRIPTION
prevents extrapolation errors and abrupt jumps in tracking that often happen as a result of reconnecting or network lag spikes