### PR TITLE
stage tracking for client + tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 .cxx/
+.cache/
 .gradle/
 _deps/
 
@@ -13,4 +14,5 @@ a.out
 *.keystore
 gradle.properties
 local.properties
+compile_commands.json
 !libopenxr_loader.so

--- a/client/scenes/stream.h
+++ b/client/scenes/stream.h
@@ -78,10 +78,9 @@ private:
 	std::unique_ptr<wivrn_session> network_session;
 	std::atomic<bool> exiting = false;
 	std::thread network_thread;
-	std::mutex local_floor_mutex;
-	xr::space local_floor;
 	std::mutex tracking_control_mutex;
 	to_headset::tracking_control tracking_control;
+	std::atomic<bool> local_dirty = false;
 	std::atomic<XrDuration> display_time_phase = 0;
 	std::atomic<XrDuration> display_time_period = 0;
 	std::optional<std::thread> tracking_thread;
@@ -230,7 +229,6 @@ private:
 
 	void accumulate_metrics(XrTime predicted_display_time, const std::vector<std::shared_ptr<shard_accumulator::blit_handle>> & blit_handles, const gpu_timestamps & timestamps);
 	XrCompositionLayerQuad plot_performance_metrics(XrTime predicted_display_time);
-	void update_local_floor(XrTime when);
 	void on_reference_space_changed(XrReferenceSpaceType space, XrTime) override;
 };
 } // namespace scenes

--- a/client/scenes/stream_tracking.cpp
+++ b/client/scenes/stream_tracking.cpp
@@ -183,7 +183,7 @@ void scenes::stream::tracking()
 	auto get_int_extra = jni::klass("android/content/Intent").method<jni::Int>("getIntExtra", level_jstr, default_jint);
 
 	XrTime next_battery_check = 0;
-	const XrDuration battery_check_interval = 5'000'000'000; // 5s
+	const XrDuration battery_check_interval = 30'000'000'000; // 30s
 #endif
 	std::vector<std::pair<device_id, XrSpace>> spaces = {
 	        {device_id::HEAD, application::view()},

--- a/common/wivrn_packets.h
+++ b/common/wivrn_packets.h
@@ -131,6 +131,11 @@ struct tracking
 		position_tracked = 1 << 5
 	};
 
+	enum state_flags : uint8_t
+	{
+		recentered = 1 << 0,
+	};
+
 	struct pose
 	{
 		device_id device;
@@ -149,7 +154,9 @@ struct tracking
 
 	XrTime production_timestamp;
 	XrTime timestamp;
-	XrViewStateFlags flags;
+	XrViewStateFlags view_flags;
+
+	uint8_t state_flags;
 
 	std::array<view, 2> views;
 	std::vector<pose> device_poses;

--- a/server/driver/history.h
+++ b/server/driver/history.h
@@ -106,7 +106,7 @@ public:
 		std::lock_guard lock(mutex);
 		std::chrono::nanoseconds ex(std::max<XrTime>(0, at_timestamp_ns - last_produced));
 
-		last_request = at_timestamp_ns;
+		last_request = os_monotonic_get_ns();
 
 		if (data.empty())
 		{

--- a/server/driver/view_list.cpp
+++ b/server/driver/view_list.cpp
@@ -45,7 +45,7 @@ bool view_list::update_tracking(const from_headset::tracking & tracking, const c
 		tracked_views view{};
 
 		view.relation = pose_list::convert_pose(pose);
-		view.flags = tracking.flags;
+		view.flags = tracking.view_flags;
 
 		for (size_t eye = 0; eye < 2; ++eye)
 		{

--- a/server/driver/wivrn_session.h
+++ b/server/driver/wivrn_session.h
@@ -83,7 +83,6 @@ class wivrn_session : public std::enable_shared_from_this<wivrn_session>
 
 	u_system & xrt_system;
 	xrt_space_overseer * space_overseer;
-	xrt_vec3 reconnect_offset{}; // z is used to store reconnect flag: 0 is none, non 0 means offset needs to be applied
 
 	std::atomic<bool> quit = false;
 	std::thread thread;


### PR DESCRIPTION
The stage tracking is the larger commit, probably look at that one separately. the others are straightforward.

I changed it to re-center Monado stage instead of tracking origin offset. this preserves calibration between different tracking origins.

From my testing, recenter action seems indistinguishable from the previous method; you will be standing in the center and facing towards the game world's forward direction. Floor level is not touched.

I also switched it to monitor local space only, as to my knowledge, local only changes when recentering, while stage/local_floor may change when the floor level changes.