### PR TITLE
expose controllers via MNDX_xdev_space, update monado

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,7 +203,7 @@ FetchContent_Declare(imgui         EXCLUDE_FROM_ALL URL https://github.com/ocorn
 FetchContent_Declare(monado
     GIT_REPOSITORY   https://gitlab.freedesktop.org/monado/monado
     # also change in flatpak/io.github.wivrn.wivrn.yml !!!
-    GIT_TAG          bcbe19ddd795f182df42051e5495e9727db36c1c
+    GIT_TAG          01806a3ffa62a2440da83d94e7a9297645d9d95a
     PATCH_COMMAND    ${CMAKE_CURRENT_LIST_DIR}/patches/apply.sh ${CMAKE_CURRENT_LIST_DIR}/patches/monado/
     EXCLUDE_FROM_ALL
     )

--- a/flatpak/io.github.wivrn.wivrn.yml
+++ b/flatpak/io.github.wivrn.wivrn.yml
@@ -161,7 +161,7 @@ modules:
         sha256: 6f490ec1383de5855dcf801c23f0a967f888eb6e1440b6ca0bf36c12d4ae7ac7
       - type: git
         url: https://gitlab.freedesktop.org/monado/monado
-        tag: bcbe19ddd795f182df42051e5495e9727db36c1c
+        tag: 01806a3ffa62a2440da83d94e7a9297645d9d95a
         dest: deps/monado-src
       - type: shell
         commands:

--- a/server/driver/wivrn_session.cpp
+++ b/server/driver/wivrn_session.cpp
@@ -169,6 +169,19 @@ xrt_result_t xrt::drivers::wivrn::wivrn_session::create_session(xrt::drivers::wi
 	xrt_device * active_left_hand = nullptr;
 	xrt_device * active_right_hand = nullptr;
 
+	if (self->left_hand)
+	{
+		devices->xdevs[n++] = self->left_hand.get();
+		active_left_hand = self->left_hand.get();
+		usysds->base.base.static_roles.hand_tracking.left = self->left_hand.get();
+	}
+	if (self->right_hand)
+	{
+		devices->xdevs[n++] = self->right_hand.get();
+		active_right_hand = self->right_hand.get();
+		usysds->base.base.static_roles.hand_tracking.right = self->right_hand.get();
+	}
+
 #ifdef WIVRN_FEATURE_STEAMVR_LIGHTHOUSE
 	auto use_steamvr_lh = std::getenv("WIVRN_USE_STEAMVR_LH");
 	xrt_system_devices * lhdevs = NULL;
@@ -196,18 +209,6 @@ xrt_result_t xrt::drivers::wivrn::wivrn_session::create_session(xrt::drivers::wi
 	}
 #endif
 
-	if (self->left_hand && !active_left_hand)
-	{
-		active_left_hand = self->left_hand.get();
-		devices->xdevs[n++] = self->left_hand.get();
-		usysds->base.base.static_roles.hand_tracking.left = self->left_hand.get();
-	}
-	if (self->right_hand && !active_right_hand)
-	{
-		active_right_hand = self->right_hand.get();
-		devices->xdevs[n++] = self->right_hand.get();
-		usysds->base.base.static_roles.hand_tracking.right = self->right_hand.get();
-	}
 	if (self->info.eye_gaze)
 	{
 		self->eye_tracker = std::make_unique<wivrn_eye_tracker>(self->hmd.get(), self);


### PR DESCRIPTION
changes:
- expose wivrn controllers via MNDX_xdev_space even if index is being used. this is so that people can still use them to calibrate (motoc)
- update monado so that more people have access to test `U_PACING_APP_IMMEDIATE_WAIT_FRAME_RETURN`