### PR TITLE
Store proxy HMD and controller devices by value

### DIFF
--- a/server/driver/view_list.h
+++ b/server/driver/view_list.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "pose_list.h"
-#include "wivrn_session.h"
+#include "wivrn_connection.h"
 
 struct tracked_views
 {

--- a/server/driver/wivrn_controller.cpp
+++ b/server/driver/wivrn_controller.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "wivrn_controller.h"
+#include "wivrn_session.h"
 
 #include "util/u_logging.h"
 #include <stdio.h>
@@ -150,7 +151,7 @@ static void wivrn_controller_update_inputs(xrt_device * xdev);
 
 wivrn_controller::wivrn_controller(int hand_id,
                                    xrt_device * hmd,
-                                   std::shared_ptr<xrt::drivers::wivrn::wivrn_session> cnx) :
+                                   xrt::drivers::wivrn::wivrn_session * cnx) :
         xrt_device{},
         grip(hand_id == 0 ? device_id::LEFT_GRIP : device_id::RIGHT_GRIP),
         aim(hand_id == 0 ? device_id::LEFT_AIM : device_id::RIGHT_AIM),
@@ -388,7 +389,7 @@ void wivrn_controller::set_output(xrt_output_name name, const xrt_output_value *
 
 static void wivrn_controller_destroy(xrt_device * xdev)
 {
-	delete (wivrn_controller *)xdev;
+	static_cast<wivrn_controller *>(xdev)->unregister();
 }
 
 static void wivrn_controller_update_inputs(xrt_device * xdev)

--- a/server/driver/wivrn_controller.h
+++ b/server/driver/wivrn_controller.h
@@ -23,11 +23,16 @@
 
 #include "hand_joints_list.h"
 #include "pose_list.h"
-#include "wivrn_session.h"
+#include "wivrn_connection.h"
 
 #include <memory>
 #include <mutex>
 #include <vector>
+
+namespace xrt::drivers::wivrn
+{
+class wivrn_session;
+}
 
 class wivrn_controller : public xrt_device
 {
@@ -41,10 +46,10 @@ class wivrn_controller : public xrt_device
 	std::vector<xrt_input> inputs_array;
 	xrt_output haptic_output;
 
-	std::shared_ptr<xrt::drivers::wivrn::wivrn_session> cnx;
+	xrt::drivers::wivrn::wivrn_session * cnx;
 
 public:
-	wivrn_controller(int hand_id, xrt_device * hmd, std::shared_ptr<xrt::drivers::wivrn::wivrn_session> cnx);
+	wivrn_controller(int hand_id, xrt_device * hmd, xrt::drivers::wivrn::wivrn_session * cnx);
 
 	void unregister()
 	{

--- a/server/driver/wivrn_hmd.cpp
+++ b/server/driver/wivrn_hmd.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "wivrn_hmd.h"
+#include "wivrn_session.h"
 
 #include "xrt/xrt_defines.h"
 #include "xrt/xrt_device.h"
@@ -196,7 +197,7 @@ bool wivrn_hmd::wivrn_hmd_compute_distortion(xrt_device * xdev, uint32_t view_in
 	return true;
 }
 
-wivrn_hmd::wivrn_hmd(std::shared_ptr<xrt::drivers::wivrn::wivrn_session> cnx,
+wivrn_hmd::wivrn_hmd(xrt::drivers::wivrn::wivrn_session * cnx,
                      const from_headset::headset_info_packet & info) :
         xrt_device{}, cnx(cnx)
 {

--- a/server/driver/wivrn_hmd.h
+++ b/server/driver/wivrn_hmd.h
@@ -23,7 +23,7 @@
 #include "xrt/xrt_tracking.h"
 
 #include "view_list.h"
-#include "wivrn_session.h"
+#include "wivrn_connection.h"
 
 #include <array>
 #include <cstdint>
@@ -31,6 +31,11 @@
 #include <mutex>
 
 struct comp_target;
+
+namespace xrt::drivers::wivrn
+{
+class wivrn_session;
+}
 
 class wivrn_hmd : public xrt_device
 {
@@ -50,12 +55,12 @@ class wivrn_hmd : public xrt_device
 	std::array<to_headset::foveation_parameter, 2> foveation_parameters{};
 	from_headset::battery battery{};
 
-	std::shared_ptr<xrt::drivers::wivrn::wivrn_session> cnx;
+	xrt::drivers::wivrn::wivrn_session * cnx;
 
 	static bool wivrn_hmd_compute_distortion(xrt_device * xdev, uint32_t view_index, float u, float v, xrt_uv_triplet * result);
 
 public:
-	wivrn_hmd(std::shared_ptr<xrt::drivers::wivrn::wivrn_session> cnx,
+	wivrn_hmd(xrt::drivers::wivrn::wivrn_session * cnx,
 	          const from_headset::headset_info_packet & info);
 	void unregister()
 	{

--- a/server/driver/wivrn_session.h
+++ b/server/driver/wivrn_session.h
@@ -21,6 +21,8 @@
 
 #include "clock_offset.h"
 #include "wivrn_connection.h"
+#include "wivrn_controller.h"
+#include "wivrn_hmd.h"
 #include "wivrn_ipc.h"
 #include "wivrn_packets.h"
 #include "xrt/xrt_defines.h"
@@ -31,8 +33,6 @@
 #include <mutex>
 #include <thread>
 
-class wivrn_hmd;
-class wivrn_controller;
 class wivrn_eye_tracker;
 class wivrn_fb_face2_tracker;
 class wivrn_foveation;
@@ -88,9 +88,9 @@ class wivrn_session : public std::enable_shared_from_this<wivrn_session>
 	std::atomic<bool> quit = false;
 	std::thread thread;
 
-	std::unique_ptr<wivrn_hmd> hmd;
-	std::unique_ptr<wivrn_controller> left_hand;
-	std::unique_ptr<wivrn_controller> right_hand;
+	wivrn_hmd hmd;
+	wivrn_controller left_hand;
+	wivrn_controller right_hand;
 	std::unique_ptr<wivrn_eye_tracker> eye_tracker;
 	std::unique_ptr<wivrn_fb_face2_tracker> fb_face2_tracker;
 	std::unique_ptr<wivrn_foveation> foveation;


### PR DESCRIPTION
The `unique_ptr`s for `wivrn_session::hmd`, `wivrn_session::left_hand`, `wivrn_session::right_hand` share the lifetime of their containing class, so they can be stored by value. The hoisted constructors have no side effects except for configuration reading done in `wivrn_hmd()`, for which exceptions will now be caught instead unwinding unchecked.