### PR TITLE
Fix dashboard crash when steam apps list does not exist

### DIFF
--- a/dashboard/steam_app.cpp
+++ b/dashboard/steam_app.cpp
@@ -54,7 +54,22 @@ std::vector<steam_app> steam_apps(const std::string & locale)
 {
 	std::vector<steam_app> apps;
 
-	nlohmann::json json = nlohmann::json::parse(read_vr_manifest());
+	auto manifest = read_vr_manifest();
+	if (manifest.empty())
+	{
+		return apps;
+	}
+
+	nlohmann::json json;
+	try
+	{
+		json = nlohmann::json::parse(manifest);
+	}
+	catch (std::exception & e)
+	{
+		std::cerr << e.what() << std::endl;
+		return apps;
+	}
 
 	for (auto & i: json["applications"])
 	{


### PR DESCRIPTION
This fixes a dashboard crash when `~/.steam/steam/config/steamapps.vrmanifest` does not exist. This can happen when the user doesn't have Steam or is using the Flatpak.

```
terminate called after throwing an instance of 'nlohmann::json_abi_v3_11_3::detail::parse_error'
  what():  [json.exception.parse_error.101] parse error at line 1, column 1: attempting to parse an empty input; check that your input string or stream contains the expected JSON
[1]    98422 IOT instruction (core dumped)  build-dashboard/server/wivrn-dashboard
```