### PR TITLE
support building wivrnctl with elogind

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,7 +224,7 @@ endif()
 
 if (WIVRN_BUILD_WIVRNCTL)
     find_package(CLI11 REQUIRED)
-    pkg_check_modules(SYSTEMD REQUIRED IMPORTED_TARGET libsystemd)
+    pkg_search_module(SYSTEMD REQUIRED IMPORTED_TARGET libsystemd libelogind)
 endif()
 
 # Common dependencies


### PR DESCRIPTION
not sure if you consider this proper enough, it does build and work fine with everything else having WIVRN_USE_SYSTEMD off