### PR TITLE
Replace resolution dropdown with a slider; Increase limit to 350%

### DIFF
--- a/client/locale/es/wivrn.po
+++ b/client/locale/es/wivrn.po
@@ -135,10 +135,10 @@ msgstr "Frecuencia de actualización"
 msgid "Resolution scale"
 msgstr "Escala de resolución"
 
-#: client/scenes/lobby_gui.cpp:611 client/scenes/lobby_gui.cpp:615
+#: client/scenes/lobby_gui.cpp:611
 #, c++-format
-msgid "{} - {}x{} per eye"
-msgstr "{} - {}x{} por ojo"
+msgid "%d%% - {}x{} per eye"
+msgstr "%d%% - {}x{} por ojo"
 
 #: client/scenes/lobby_gui.cpp:628
 msgid "Enable microphone"

--- a/client/locale/es/wivrn.po
+++ b/client/locale/es/wivrn.po
@@ -140,6 +140,11 @@ msgstr "Escala de resolución"
 msgid "%d%% - {}x{} per eye"
 msgstr "%d%% - {}x{} por ojo"
 
+#: client/scenes/lobby_gui.cpp:621
+#, c++-format
+msgid "Resolution larger than {}x{} may not be supported by the headset"
+msgstr "La resolución mayor que {}x{} podría no ser compatible con el visor"
+
 #: client/scenes/lobby_gui.cpp:628
 msgid "Enable microphone"
 msgstr "Activar micrófono"

--- a/client/locale/fr/wivrn.po
+++ b/client/locale/fr/wivrn.po
@@ -136,10 +136,10 @@ msgstr "Taux de rafraichissement"
 msgid "Resolution scale"
 msgstr "Échelle"
 
-#: client/scenes/lobby_gui.cpp:610 client/scenes/lobby_gui.cpp:614
+#: client/scenes/lobby_gui.cpp:611
 #, c++-format
-msgid "{}% - {}x{} per eye"
-msgstr "{}% - {}x{} par œil"
+msgid "%d%% - {}x{} per eye"
+msgstr "%d%% - {}x{} par œil"
 
 #: client/scenes/lobby_gui.cpp:627
 #, c++-format

--- a/client/locale/it/wivrn.po
+++ b/client/locale/it/wivrn.po
@@ -135,10 +135,10 @@ msgstr "Frequenza di aggiornamento"
 msgid "Resolution scale"
 msgstr "Scala di risoluzione"
 
-#: client/scenes/lobby_gui.cpp:610 client/scenes/lobby_gui.cpp:614
+#: client/scenes/lobby_gui.cpp:611
 #, c++-format
-msgid "{}% - {}x{} per eye"
-msgstr "{}% - {}x{} per occhio"
+msgid "%d%% - {}x{} per eye"
+msgstr "%d%% - {}x{} per occhio"
 
 #: client/scenes/lobby_gui.cpp:627
 #, c++-format

--- a/client/locale/ja/wivrn.po
+++ b/client/locale/ja/wivrn.po
@@ -135,10 +135,10 @@ msgstr "リフレッシュレート"
 msgid "Resolution scale"
 msgstr "解像度"
 
-#: client/scenes/lobby_gui.cpp:610 client/scenes/lobby_gui.cpp:614
+#: client/scenes/lobby_gui.cpp:611
 #, c++-format
-msgid "{}% - {}x{} per eye"
-msgstr "{}% - 目あたり{}x{}"
+msgid "%d%% - {}x{} per eye"
+msgstr "%d%% - 目あたり{}x{}"
 
 #: client/scenes/lobby_gui.cpp:627
 #, c++-format

--- a/client/scenes/lobby_gui.cpp
+++ b/client/scenes/lobby_gui.cpp
@@ -608,7 +608,7 @@ void scenes::lobby::gui_settings()
 		const auto width = stream_view.recommendedImageRectWidth;
 		const auto height = stream_view.recommendedImageRectHeight;
 		auto intScale = int(current * 100);
-		if (ImGui::SliderInt(_S("Resolution scale"), &intScale, 50, 500, fmt::format(_F("%d%% - {}x{} per eye"), int(width * current), int(height * current)).c_str()))
+		if (ImGui::SliderInt(_S("Resolution scale"), &intScale, 50, 350, fmt::format(_F("%d%% - {}x{} per eye"), int(width * current), int(height * current)).c_str()))
 		{
 			config.resolution_scale = intScale * 0.01;
 			config.save();

--- a/client/scenes/lobby_gui.cpp
+++ b/client/scenes/lobby_gui.cpp
@@ -607,17 +607,11 @@ void scenes::lobby::gui_settings()
 		const auto current = config.resolution_scale;
 		const auto width = stream_view.recommendedImageRectWidth;
 		const auto height = stream_view.recommendedImageRectHeight;
-		if (ImGui::BeginCombo(_S("Resolution scale"), fmt::format(_F("{}% - {}x{} per eye"), int(current * 100), int(width * current), int(height * current)).c_str()))
+		auto intScale = int(current * 100);
+		if (ImGui::SliderInt(_S("Resolution scale"), &intScale, 50, 500, fmt::format(_F("%d%% - {}x{} per eye"), int(width * current), int(height * current)).c_str()))
 		{
-			for (int scale = 50; scale <= 200; scale += 10)
-			{
-				if (ImGui::Selectable(fmt::format(_F("{}% - {}x{} per eye"), scale, (width * scale) / 100, (height * scale) / 100).c_str(), scale == current, ImGuiSelectableFlags_SelectOnRelease) and scale != current)
-				{
-					config.resolution_scale = scale * 0.01;
-					config.save();
-				}
-			}
-			ImGui::EndCombo();
+			config.resolution_scale = intScale * 0.01;
+			config.save();
 		}
 		vibrate_on_hover();
 		if (width * config.resolution_scale > stream_view.maxImageRectWidth or height * config.resolution_scale > stream_view.maxImageRectHeight)


### PR DESCRIPTION
As the title says. The increased range now matches SteamVR settings, and the slider allows for more granular control while avoiding a huge dropdown list.

The primary motivation for this is to play VTOL VR at 300% resolution, as I do on Windows with Steam Link.