### PR TITLE
Add section about Steam Flatpak usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,23 @@ If using Wine/Proton, it will probe for OpenVR at startup, so even for OpenXR ap
 
 When you start the server through flatpak, it will automatically configure the current OpenVR to use OpenComposite.
 
+### Steam Flatpak
+
+If you're using the Steam Flatpak, you'll need to grant read only access to the following paths:
+
+```bash
+flatpak override --user \
+  --filesystem=xdg-run/wivrn:ro \
+  --filesystem=xdg-data/flatpak/app/io.github.wivrn.wivrn:ro \
+  --filesystem=xdg-config/openxr:ro \
+  com.valvesoftware.Steam
+```
+
+Then create a symlink for the OpenXR configuration file (the directory `~/.var/app/com.valvesoftware.Steam/.config/openxr` will need to be created if it doesn't already exist):
+
+```bash
+ln -s ~/.config/openxr/1 ~/.var/app/com.valvesoftware.Steam/.config/openxr/1
+```
 
 ### Audio
 When the headset is connected, WiVRn will create a virtual output device named WiVRn. It is not selected as default and you should either assign the application to the device when it is running, or mark it as default. To do so you can use `pavucontrol` or your desktop environment's configuration panel. Please note that in `pavucontrol` it will appear as a virtual device.


### PR DESCRIPTION
# Context

Unless I missed some mention of it, I didn't see any discussion about using WiVRn with the Flatpak version of Steam, which doesn't work out of the box. After spending some time testing and confirming each of these settings, I found that these steps are what are needed to get things working (at least with VRChat).
# Rationale

I wanted to avoid the combination of the `--filesystem=xdg-config/openxr:ro` permission and the symlink, by using the `--persist=.config/openxr` permission instead, but this was more annoying because it doesn't work if WiVRn is started before the Steam Flatpak (whereas the symlink doesn't rely on anything starting first).

Additionally, I originally wanted to just symlink `~/.config/openxr` and not `~/.config/openxr/1`, but this is seemingly incompatible with the `--filesystem=xdg-config/openxr:ro` permission. 