### PR TITLE
Forward systemName from client system properties

### DIFF
--- a/client/scenes/stream.cpp
+++ b/client/scenes/stream.cpp
@@ -158,6 +158,7 @@ std::shared_ptr<scenes::stream> scenes::stream::create(std::unique_ptr<wivrn_ses
 		info.face_tracking2_fb = config.check_feature(feature::face_tracking);
 		info.palm_pose = application::space(xr::spaces::palm_left) or application::space(xr::spaces::palm_right);
 		info.passthrough = self->system.passthrough_supported() != xr::system::passthrough_type::no_passthrough;
+		info.system_name = std::string(self->system.properties().systemName);
 
 		audio::get_audio_description(info);
 		if (not(config.check_feature(feature::microphone)))

--- a/common/wivrn_packets.h
+++ b/common/wivrn_packets.h
@@ -150,6 +150,7 @@ struct headset_info_packet
 	bool palm_pose;
 	bool passthrough;
 	std::vector<video_codec> supported_codecs; // from preferred to least preferred
+	std::string system_name;
 };
 
 struct handshake

--- a/server/driver/wivrn_session.cpp
+++ b/server/driver/wivrn_session.cpp
@@ -220,6 +220,8 @@ wivrn::wivrn_session::wivrn_session(std::unique_ptr<wivrn_connection> connection
 		roles.right_profile = xdevs[roles.right]->name;
 	if (roles.gamepad >= 0)
 		roles.gamepad_profile = xdevs[roles.gamepad]->name;
+
+	memcpy(xrt_system.base.properties.name, get_info().system_name.c_str(), get_info().system_name.length());
 }
 
 wivrn_session::~wivrn_session()

--- a/server/driver/wivrn_session.cpp
+++ b/server/driver/wivrn_session.cpp
@@ -40,6 +40,7 @@
 #include <cmath>
 #include <magic_enum.hpp>
 #include <stdexcept>
+#include <string.h>
 #include <vulkan/vulkan.h>
 
 #if WIVRN_FEATURE_STEAMVR_LIGHTHOUSE
@@ -221,7 +222,11 @@ wivrn::wivrn_session::wivrn_session(std::unique_ptr<wivrn_connection> connection
 	if (roles.gamepad >= 0)
 		roles.gamepad_profile = xdevs[roles.gamepad]->name;
 
-	memcpy(xrt_system.base.properties.name, get_info().system_name.c_str(), get_info().system_name.length());
+	if (auto system_name = get_info().system_name; !system_name.empty())
+	{
+		system_name += " on WiVRn";
+		strlcpy(xrt_system.base.properties.name, system_name.c_str(), std::size(xrt_system.base.properties.name));
+	}
 }
 
 wivrn_session::~wivrn_session()


### PR DESCRIPTION
Used Beat Saber leaderboard mod BeatLeader for testing. Without this change, replays submitted when playing on WiVRn are displayed as 'Unknown headset with Oculus Touch controllers'. On my Quest 3 with this change, it properly displays as 'Quest 3 with Oculus Touch controllers', consistent with replays from Windows with Quest Link.