### PR TITLE
Typo on client screen when connected

### DIFF
--- a/client/scenes/lobby_gui.cpp
+++ b/client/scenes/lobby_gui.cpp
@@ -200,7 +200,7 @@ void scenes::lobby::gui_connecting(locked_notifiable<pin_request_data> & pin_req
 	if (server_name == "")
 		CenterTextH(fmt::format(_F("Connection")));
 	else
-		CenterTextH(fmt::format(_F("Connection to {}"), server_name));
+		CenterTextH(fmt::format(_F("Connected to {}"), server_name));
 	ImGui::PopFont();
 
 	// ImGui::TextWrapped("%s", status.first.c_str());


### PR DESCRIPTION
A very pedantic one here but just thought I'd add it anyway. On my headset when connected I would get a screen saying "Connection to fedora" (fedora being the name of my PC.

I'm assuming the intention was that it should say "Connected to fedora" instead.