### PR TITLE
Add option to use a palm offset

### DIFF
--- a/server/driver/configuration.cpp
+++ b/server/driver/configuration.cpp
@@ -110,6 +110,11 @@ configuration configuration::read_user_configuration()
 				result.scale = *it;
 		}
 
+		if (auto it = json.find("grip-surface"); it != json.end())
+		{
+			result.grip_surface = *it;
+		}
+
 		if (auto it = json.find("bitrate"); it != json.end())
 			result.bitrate = *it;
 

--- a/server/driver/configuration.h
+++ b/server/driver/configuration.h
@@ -55,6 +55,7 @@ struct configuration
 	std::optional<encoder> encoder_passthrough;
 	std::optional<int> bitrate;
 	std::optional<std::array<double, 2>> scale;
+	std::optional<std::array<float, 3>> grip_surface;
 	std::vector<std::string> application;
 	bool tcp_only = false;
 	service_publication publication = service_publication::avahi;

--- a/server/driver/pose_list.cpp
+++ b/server/driver/pose_list.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "pose_list.h"
+#include "math/m_api.h"
 #include "math/m_eigen_interop.hpp"
 #include "math/m_space.h"
 #include "math/m_vec3.h"
@@ -69,7 +70,9 @@ bool pose_list::update_tracking(const from_headset::tracking & tracking, const c
 		if (pose.device != device)
 			continue;
 
-		return add_sample(tracking.production_timestamp, tracking.timestamp, convert_pose(pose), offset);
+		xrt_space_relation new_pose = convert_pose(pose);
+		math_quat_rotate(&new_pose.pose.orientation, &rotation_offset, &new_pose.pose.orientation);
+		return add_sample(tracking.production_timestamp, tracking.timestamp, new_pose, offset);
 	}
 	return true;
 }

--- a/server/driver/pose_list.h
+++ b/server/driver/pose_list.h
@@ -31,12 +31,14 @@ class pose_list : public history<pose_list, xrt_space_relation>
 {
 public:
 	const wivrn::device_id device;
+	const xrt_quat rotation_offset;
 
 	static xrt_space_relation interpolate(const xrt_space_relation & a, const xrt_space_relation & b, float t);
 	static xrt_space_relation extrapolate(const xrt_space_relation & a, const xrt_space_relation & b, int64_t ta, int64_t tb, int64_t t);
 
-	pose_list(wivrn::device_id id) :
-	        device(id) {}
+	pose_list(wivrn::device_id id, xrt_quat rotation_quat = xrt_quat{0.0, 0.0, 0.0, 1.0}) :
+	        device(id),
+	        rotation_offset(rotation_quat) {}
 
 	bool update_tracking(const wivrn::from_headset::tracking &, const clock_offset & offset);
 

--- a/server/driver/pose_list.h
+++ b/server/driver/pose_list.h
@@ -36,7 +36,7 @@ public:
 	static xrt_space_relation interpolate(const xrt_space_relation & a, const xrt_space_relation & b, float t);
 	static xrt_space_relation extrapolate(const xrt_space_relation & a, const xrt_space_relation & b, int64_t ta, int64_t tb, int64_t t);
 
-	pose_list(wivrn::device_id id, xrt_quat rotation_quat = xrt_quat{0.0, 0.0, 0.0, 1.0}) :
+	pose_list(wivrn::device_id id, xrt_quat rotation_quat = XRT_QUAT_IDENTITY) :
 	        device(id),
 	        rotation_offset(rotation_quat) {}
 

--- a/server/driver/wivrn_controller.cpp
+++ b/server/driver/wivrn_controller.cpp
@@ -221,22 +221,17 @@ static std::ofstream & tracking_dump()
 
 static auto make_palm(int hand_id, bool palm_pose)
 {
-	std::optional<std::array<float, 3>> grip_surface = configuration::read_user_configuration().grip_surface;
-	if (palm_pose && !grip_surface)
-	{
-		return pose_list((hand_id == 0 ? device_id::LEFT_PALM : device_id::RIGHT_PALM));
-	}
-	else if (grip_surface)
+	if (auto grip_surface = configuration::read_user_configuration().grip_surface)
 	{
 		std::array<float, 3> angles = grip_surface.value();
 		float deg_2_rad = std::numbers::pi / 180.0;
-		xrt_vec3 rotation_angles = xrt_vec3{angles[0] * deg_2_rad, angles[1] * deg_2_rad, angles[2] * deg_2_rad};
+		xrt_vec3 rotation_angles{angles[0] * deg_2_rad, angles[1] * deg_2_rad, angles[2] * deg_2_rad};
 		xrt_quat rotation_quat = XRT_QUAT_IDENTITY;
 		math_quat_from_euler_angles(&rotation_angles, &rotation_quat);
 
-		return pose_list((hand_id == 0 ? device_id::LEFT_GRIP : device_id::RIGHT_GRIP), rotation_quat);
+		return pose_list(hand_id == 0 ? device_id::LEFT_GRIP : device_id::RIGHT_GRIP, rotation_quat);
 	}
-	return pose_list((hand_id == 0 ? device_id::LEFT_PALM : device_id::RIGHT_PALM));
+	return pose_list(hand_id == 0 ? device_id::LEFT_PALM : device_id::RIGHT_PALM);
 }
 
 wivrn_controller::wivrn_controller(int hand_id,


### PR DESCRIPTION
Since some devices don't have this and its required for certain games (ie rumble and bonelab), I added an option to instead use grip pose offset by a certain rotation. Right now its hard coded but it should definitely be changed to either be in the config or somewhere in code for common devices.

Sorry for any mistakes made im not super familiar with cpp so if anything needs to be changed let me know 