### PR TITLE
Better defaults for NVENC

### DIFF
--- a/server/encoder/video_encoder_nvenc.cpp
+++ b/server/encoder/video_encoder_nvenc.cpp
@@ -190,7 +190,7 @@ video_encoder_nvenc::video_encoder_nvenc(
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	auto presetGUID = NV_ENC_PRESET_P4_GUID;
-	NV_ENC_TUNING_INFO tuningInfo = NV_ENC_TUNING_INFO_LOW_LATENCY;
+	NV_ENC_TUNING_INFO tuningInfo = NV_ENC_TUNING_INFO_ULTRA_LOW_LATENCY;
 #pragma GCC diagnostic pop
 	NV_ENC_PRESET_CONFIG preset_config{
 	        .version = NV_ENC_PRESET_CONFIG_VER,
@@ -207,6 +207,7 @@ video_encoder_nvenc::video_encoder_nvenc(
 	params.rcParams.maxBitRate = bitrate;
 	params.rcParams.vbvBufferSize = bitrate / fps;
 	params.rcParams.vbvInitialDelay = bitrate / fps;
+	params.rcParams.multiPass = NV_ENC_TWO_PASS_QUARTER_RESOLUTION;
 
 	params.gopLength = NVENC_INFINITE_GOPLENGTH;
 	params.frameIntervalP = 1;


### PR DESCRIPTION
All settings were tested on the RTX 4080 Super, Quest 3 with 1.4 resolution scale and dual nvenc encoders.

It seems that the multipass encoder is a must. Without it, I experienced bitrate spikes when turning around in games. With it on, the bitrate is much more stable. Going from P4, LL, Single pass to P1, ULL, 1/4 pass results in similar quality with better encoder and decoder performances. There's a little drop in quality at low bitrates, but seems a little better at higher bitrates. The drop in latency numbers seems significant, so I guess any eventual quality loss can be mitigated with a slightly higher bitrate. Since these are the defaults Sunshine uses and almost the same is used by ALVR, I guess it's safe to change.

Before taking the screenshots with the graphs, I quickly rotated in the game to check for bitrate fluctuations.

Screenshots from tests:
https://drive.google.com/drive/folders/1XiOSHf1Dof0uS023TlPv5UZHNj9hF34a?usp=sharing

Comparison of the current preset (P4, tuning Low Latency, Single pass) to the proposed setting (P1, tuning Ultra Low Latency, Two-pass Quarter):

### H264 50

| Scene      | Config   | Encoding Latency        | Motion to Photons | Displayed on Graph |
|-----------|---------|-------------------------|-------------------|--------------------|
| Alyx      | Current | [1475, 1509]            | 55                | 42/45              |
| Skyrim_1  | Current | [2260, 2044]            | 68                | 40/50              |
| Skyrim_2  | Current | [2247, 2154]            | 69                | 44/51              |
| Alyx      | New     | [1051, 1052]            | 53                | 39/44              |
| Skyrim_1  | New     | [1575, 1467]            | 64                | 40/48              |
| Skyrim_2  | New     | [1508, 1555]            | 65                | 41/50              |

### H264 300

| Scene      | Config   | Encoding Latency        | Motion to Photons | Displayed on Graph |
|-----------|---------|-------------------------|-------------------|--------------------|
| Alyx      | Current | [1476, 1460]            | 56                | 43/48              |
| Skyrim_1  | Current | [2189, 2035]            | 71                | 46/51              |
| Skyrim_2  | Current | [2139, 2155]            | 74                | 48/56              |
| Alyx      | New     | [1610, 1579]            | 57                | 45/49              |
| Skyrim_1  | New     | [2091, 2050]            | 74                | 48/55              |
| Skyrim_2  | New     | [2030, 2165]            | 76                | 50/55              |

### H265 50

| Scene      | Config   | Encoding Latency        | Motion to Photons | Displayed on Graph |
|-----------|---------|-------------------------|-------------------|--------------------|
| Alyx      | Current | [939, 916]              | 52                | 38/42              |
| Skyrim_1  | Current | [1523, 1154]            | 65                | 41/47              |
| Skyrim_2  | Current | [1465, 1577]            | 64                | 40/48              |
| Alyx      | New     | [935, 926]              | 53                | 41/43              |
| Skyrim_1  | New     | [1451, 1188]            | 64                | 41/47              |
| Skyrim_2  | New     | [1420, 1474]            | 66                | 40/48              |

### H265 150

| Scene      | Config   | Encoding Latency        | Motion to Photons | Displayed on Graph |
|-----------|---------|-------------------------|-------------------|--------------------|
| Alyx      | Current | [1750, 1781]            | 61                | 46/50              |
| Skyrim_1  | Current | [2244, 2182]            | 71                | 48/52              |
| Skyrim_2  | Current | [2181, 2335]            | 72                | 48/52              |
| Alyx      | New     | [1105, 1134]            | 55                | 45/48              |
| Skyrim_1  | New     | [1612, 1477]            | 70                | 46/50              |
| Skyrim_2  | New     | [1541, 1662]            | 71                | 47/52              |

### AV1 50

| Scene      | Config   | Encoding Latency        | Motion to Photons | Displayed on Graph |
|-----------|---------|-------------------------|-------------------|--------------------|
| Alyx      | Current | [1189, 1188]            | 51                | 40/43              |
| Skyrim_1  | Current | [1714, 1720]            | 61                | 38/43              |
| Skyrim_2  | Current | [1597, 1610]            | 63                | 39/45              |
| Alyx      | New     | [935, 936]              | 57                | 40/44              |
| Skyrim_1  | New     | [1480, 1319]            | 64                | 40/48              |
| Skyrim_2  | New     | [1393, 1549]            | 66                | 40/46              |

### AV1 150

| Scene      | Config   | Encoding Latency        | Motion to Photons | Displayed on Graph |
|-----------|---------|-------------------------|-------------------|--------------------|
| Alyx      | Current | [1008, 1032]            | 57                | 42/45              |
| Skyrim_1  | Current | [1754, 1451]            | 68                | 45/48              |
| Skyrim_2  | Current | [1452, 1536]            | 69                | 45/50              |
| Alyx      | New     | [1002, 1033]            | 53                | 40/43              |
| Skyrim_1  | New     | [1544, 1363]            | 68                | 42/50              |
| Skyrim_2  | New     | [1468, 1573]            | 72                | 45/51              |

I'm really impressed with AV1, it's lower latency and better quality than h265, but high bitrate H264 is still king.

It would be great if someone with more NVENC expertise could comment on this (@ehfd?). Additionally, it would be beneficial if someone could test these settings on other headsets and GPUs. It's probably worth looking into adaptive quantization, but I've found reports that it could degrade quality in some cases like dark scenes.

If anyone wants to join the testing, I've created a branch with the possibility to change basic options via config. If needed, I can add more: 
https://github.com/Kierek/WiVRn/tree/nvenc_options
