### PR TITLE
fix forced extensions not working for face

### DIFF
--- a/server/driver/wivrn_session.cpp
+++ b/server/driver/wivrn_session.cpp
@@ -200,20 +200,17 @@ wivrn::wivrn_session::wivrn_session(std::unique_ptr<wivrn_connection> connection
 		static_roles.eyes = eye_tracker.get();
 		xdevs[xdev_count++] = eye_tracker.get();
 	}
-	switch (get_info().face_tracking)
+	if (get_info().face_tracking == wivrn::from_headset::face_type::fb2 || is_forced_extension("FB_face_tracking2"))
 	{
-		case wivrn::from_headset::face_type::fb2:
-			fb_face2_tracker = std::make_unique<wivrn_fb_face2_tracker>(&hmd, *this);
-			static_roles.face = fb_face2_tracker.get();
-			xdevs[xdev_count++] = fb_face2_tracker.get();
-			break;
-		case wivrn::from_headset::face_type::htc:
-			htc_face_tracker = std::make_unique<wivrn_htc_face_tracker>(&hmd, *this);
-			static_roles.face = htc_face_tracker.get();
-			xdevs[xdev_count++] = htc_face_tracker.get();
-			break;
-		default:
-			break;
+		fb_face2_tracker = std::make_unique<wivrn_fb_face2_tracker>(&hmd, *this);
+		static_roles.face = fb_face2_tracker.get();
+		xdevs[xdev_count++] = fb_face2_tracker.get();
+	}
+	if (get_info().face_tracking == wivrn::from_headset::face_type::htc || is_forced_extension("HTC_facial_tracking"))
+	{
+		htc_face_tracker = std::make_unique<wivrn_htc_face_tracker>(&hmd, *this);
+		static_roles.face = htc_face_tracker.get();
+		xdevs[xdev_count++] = htc_face_tracker.get();
 	}
 
 #if WIVRN_FEATURE_SOLARXR


### PR DESCRIPTION
when adding support for HTC face tracking, the `is_forced_extension` check got removed.