### PR TITLE
Add OpenVR runtime override as a setting, add --early-active-runtime to test this

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -181,3 +181,12 @@ Default value: `avahi`
 How to publish the service over the network, `avahi` or null.
 
 If set to null, service will not be published and address has to be entered manually on the headset.
+
+## `openvr-compat-path`
+Default value: unset
+
+Provides the path to the directory of an OpenVR compatibility tool (such as OpenComposite).
+
+If unset, WiVRn will autodetect the path of such a tool as usual (see [the SteamVR guide](./steamvr.md)).
+
+If set to an empty string, it is assumed detection failed ; the OpenVR configuration will not be modified and the pressure-vessel configuration won't be adjusted.

--- a/docs/steamvr.md
+++ b/docs/steamvr.md
@@ -1,9 +1,14 @@
 # Notes for OpenVR and Steam
 
-
 WiVRn only provides an OpenXR runtime. For games that use OpenVR, [OpenComposite](https://gitlab.com/znixian/OpenOVR/) should be used to translate the APIs.
-
 
 If using Steam, games will be sandboxed by pressure vessel, which is not OpenXR aware yet.
 - Files under `/usr` are mapped into `/run/host/usr`, if OpenComposite or WiVRn are installed there, make sure that `XR_RUNTIME_JSON` uses `/run/host/usr` prefix and that `VR_OVERRIDE` or `~/.config/openvr/openvrpaths.vrpath` also uses this configuration.
 - WiVRn uses a socket to communicate between the application and the server process, this socket needs to be whitelisted as `PRESSURE_VESSEL_FILESYSTEMS_RW=$XDG_RUNTIME_DIR/wivrn/comp_ipc`.
+
+By default, WiVRn attempts to automatically find OpenComposite in a number of places:
+- When WiVRn is shipped as a flatpak, it uses a provided copy of OpenComposite by default.
+- WiVRn attempts to autodetect OpenComposite in a number of places (see `OVR_COMPAT_SEARCH_PATH` in `CMakeLists.txt`).
+- The `openvr-compat-path` configuration may be used for an unexpected install location.
+
+If it is found, WiVRn adjusts the `openvrpaths.vrpath` file, and includes whitelisting the OpenComposite path and setting `VR_OVERRIDE` in the environment variables.

--- a/server/active_runtime.cpp
+++ b/server/active_runtime.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "active_runtime.h"
+#include "driver/configuration.h"
 #include "utils/flatpak.h"
 #include "utils/xdg_base_directory.h"
 #include "wivrn_config.h"
@@ -48,6 +49,12 @@ std::filesystem::path active_runtime::manifest_path()
 
 std::filesystem::path active_runtime::openvr_compat_path()
 {
+	// config can override compat path (i.e. to debug changes to OpenComposite)
+	std::optional<std::string> path_override = configuration::read_user_configuration().openvr_compat_path;
+	if (path_override.has_value())
+		return std::filesystem::path(path_override.value());
+
+	// otherwise, prefer flatpak copy if present or otherwise try to find it on the system
 	if (auto path = flatpak_key(flatpak::section::instance, "app-path"))
 		return std::filesystem::path(*path) / "OpenComposite";
 	for (auto path: std::ranges::split_view(std::string_view(OVR_COMPAT_SEARCH_PATH), std::string_view(":")))

--- a/server/driver/configuration.cpp
+++ b/server/driver/configuration.cpp
@@ -149,6 +149,11 @@ configuration configuration::read_user_configuration()
 			if (result.publication == service_publication(-1))
 				throw std::runtime_error("invalid service publication " + it->get<std::string>());
 		}
+
+		if (auto it = json.find("openvr-compat-path"); it != json.end())
+		{
+			result.openvr_compat_path = *it;
+		}
 	}
 	catch (const std::exception & e)
 	{

--- a/server/driver/configuration.h
+++ b/server/driver/configuration.h
@@ -59,6 +59,7 @@ struct configuration
 	std::vector<std::string> application;
 	bool tcp_only = false;
 	service_publication publication = service_publication::avahi;
+	std::optional<std::string> openvr_compat_path;
 
 	static void set_config_file(const std::filesystem::path &);
 	static const std::filesystem::path & get_config_file();

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -989,6 +989,7 @@ int main(int argc, char * argv[])
 	std::string config_file;
 	app.add_option("-f", config_file, "configuration file")->option_text("FILE")->check(CLI::ExistingFile);
 	auto no_active_runtime = app.add_flag("--no-manage-active-runtime")->description("don't set the active runtime on connection");
+	auto early_active_runtime = app.add_flag("--early-active-runtime")->description("forcibly manages the active runtime even if no headset present");
 	auto no_instructions = app.add_flag("--no-instructions")->group("");
 	auto no_fork = app.add_flag("--no-fork")->description("disable fork to serve connection")->group("Debug");
 	auto no_publish = app.add_flag("--no-publish-service")->description("disable publishing the service through avahi");
@@ -1001,7 +1002,14 @@ int main(int argc, char * argv[])
 
 	CLI11_PARSE(app, argc, argv);
 
-	do_active_runtime = not *no_active_runtime;
+	if (early_active_runtime)
+	{
+		do_active_runtime = false;
+		runtime_setter.emplace();
+	}
+	else
+		do_active_runtime = not *no_active_runtime;
+
 	do_fork = not *no_fork;
 	if (*no_encrypt)
 		enc_state = wivrn_connection::encryption_state::disabled;


### PR DESCRIPTION
I ran into some trouble debugging issues with Vivecraft because my attempts to patch OpenComposite were being automatically overridden by WiVRn.

It would be nice to attach a UI to this option, but I'm not sure on the details there and I'd like to keep the PR small and easily reviewed.

Being able to set the compat path is more useful than simply disabling compat override because of things like pressure-vessel bypass, which are finicky to get right.