### PR TITLE
Fix meta handtracking thumb rotation offset #147

### DIFF
--- a/client/xr/hand_tracker.cpp
+++ b/client/xr/hand_tracker.cpp
@@ -23,10 +23,7 @@
 #include "xr/session.h"
 #include <cassert>
 #include <glm/glm.hpp>
-#include <glm/gtc/matrix_transform.hpp>
-#include <glm/gtc/matrix_transform.inl>
 #include <glm/gtc/quaternion.hpp>
-#include <glm/gtx/quaternion.hpp>
 #include "hardware.h"
 
 static PFN_xrDestroyHandTrackerEXT xrDestroyHandTrackerEXT{};

--- a/client/xr/hand_tracker.cpp
+++ b/client/xr/hand_tracker.cpp
@@ -18,13 +18,13 @@
  */
 
 #include "hand_tracker.h"
+#include "hardware.h"
 #include "xr/check.h"
 #include "xr/instance.h"
 #include "xr/session.h"
 #include <cassert>
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
-#include "hardware.h"
 
 static PFN_xrDestroyHandTrackerEXT xrDestroyHandTrackerEXT{};
 
@@ -33,8 +33,8 @@ XrResult xr::destroy_hand_tracker(XrHandTrackerEXT id)
 	return xrDestroyHandTrackerEXT(id);
 }
 
-xr::hand_tracker::hand_tracker(instance & inst, session & session, const XrHandTrackerCreateInfoEXT & info): 
-	hand_id(info.hand)
+xr::hand_tracker::hand_tracker(instance & inst, session & session, const XrHandTrackerCreateInfoEXT & info) :
+        hand_id(info.hand)
 {
 	static auto xrCreateHandTrackerEXT = inst.get_proc<PFN_xrCreateHandTrackerEXT>("xrCreateHandTrackerEXT");
 	assert(xrCreateHandTrackerEXT);
@@ -76,7 +76,7 @@ std::optional<std::array<xr::hand_tracker::joint, XR_HAND_JOINT_COUNT_EXT>> xr::
 
 	if (!locations.isActive)
 		return std::nullopt;
-	
+
 	float offset_angle;
 
 	// check if we have a device that needs a thumb offset
@@ -92,7 +92,7 @@ std::optional<std::array<xr::hand_tracker::joint, XR_HAND_JOINT_COUNT_EXT>> xr::
 			else if (hand_id == XR_HAND_RIGHT_EXT)
 				offset_angle = glm::radians(90.0f);
 			break;
-		
+
 		default:
 			offset_angle = 0.0f;
 			break;
@@ -101,28 +101,26 @@ std::optional<std::array<xr::hand_tracker::joint, XR_HAND_JOINT_COUNT_EXT>> xr::
 	std::array<xr::hand_tracker::joint, XR_HAND_JOINT_COUNT_EXT> joints;
 	for (int i = 0; i < XR_HAND_JOINT_COUNT_EXT; i++)
 	{
-
 		if (i >= XR_HAND_JOINT_THUMB_METACARPAL_EXT && i <= XR_HAND_JOINT_THUMB_TIP_EXT)
 		{
 			// Need to convert the XrQuaternionf to a glm::quat to use glm::rotate
 			glm::quat q(
-				joints_pos[i].pose.orientation.w,
-				joints_pos[i].pose.orientation.x,
-				joints_pos[i].pose.orientation.y,
-				joints_pos[i].pose.orientation.z);
+			        joints_pos[i].pose.orientation.w,
+			        joints_pos[i].pose.orientation.x,
+			        joints_pos[i].pose.orientation.y,
+			        joints_pos[i].pose.orientation.z);
 
-			glm::quat offset_rotation = glm::rotate(q,offset_angle, glm::vec3(0,0,1));
+			glm::quat offset_rotation = glm::rotate(q, offset_angle, glm::vec3(0, 0, 1));
 
 			joints_pos[i].pose.orientation = {
-				.x = offset_rotation.x,
-				.y = offset_rotation.y,
-				.z = offset_rotation.z,
-				.w = offset_rotation.w,
+			        .x = offset_rotation.x,
+			        .y = offset_rotation.y,
+			        .z = offset_rotation.z,
+			        .w = offset_rotation.w,
 			};
 		}
 
 		joints[i] = {joints_pos[i], joints_vel[i]};
-
 	}
 
 	return joints;

--- a/client/xr/hand_tracker.cpp
+++ b/client/xr/hand_tracker.cpp
@@ -91,8 +91,8 @@ std::optional<std::array<xr::hand_tracker::joint, XR_HAND_JOINT_COUNT_EXT>> xr::
 
 	if (!locations.isActive)
 		return std::nullopt;
-
-
+	
+	
 	switch (guess_model())
 	{
 		case model::meta_quest_3:
@@ -117,7 +117,6 @@ std::optional<std::array<xr::hand_tracker::joint, XR_HAND_JOINT_COUNT_EXT>> xr::
 
 		if (i >= XR_HAND_JOINT_THUMB_METACARPAL_EXT && i <= XR_HAND_JOINT_THUMB_TIP_EXT)
 		{
-
 			// Need to convert the XrQuaternionf to a glm::quat to use glm::rotate
 			glm::quat q(
 				joints_pos[i].pose.orientation.w,
@@ -133,13 +132,9 @@ std::optional<std::array<xr::hand_tracker::joint, XR_HAND_JOINT_COUNT_EXT>> xr::
 				.z = offset_rotation.z,
 				.w = offset_rotation.w,
 			};
+		}
 
-			joints[i] = {joints_pos[i], joints_vel[i]};
-		}
-		else
-		{
-			joints[i] = {joints_pos[i], joints_vel[i]};
-		}
+		joints[i] = {joints_pos[i], joints_vel[i]};
 
 	}
 

--- a/client/xr/hand_tracker.cpp
+++ b/client/xr/hand_tracker.cpp
@@ -100,6 +100,8 @@ std::optional<std::array<xr::hand_tracker::joint, XR_HAND_JOINT_COUNT_EXT>> xr::
 			case model::meta_quest_3:
 			case model::meta_quest_pro:
 			case model::meta_quest_3s:
+			case model::oculus_quest:
+			case model::oculus_quest_2:
 				if (hand_id == XR_HAND_LEFT_EXT)
 					offset_angle = glm::radians(-90.0f);
 				else if (hand_id == XR_HAND_RIGHT_EXT)

--- a/client/xr/hand_tracker.cpp
+++ b/client/xr/hand_tracker.cpp
@@ -92,26 +92,28 @@ std::optional<std::array<xr::hand_tracker::joint, XR_HAND_JOINT_COUNT_EXT>> xr::
 	if (!locations.isActive)
 		return std::nullopt;
 
+
+	switch (guess_model())
+	{
+		case model::meta_quest_3:
+		case model::meta_quest_pro:
+		case model::meta_quest_3s:
+		case model::oculus_quest:
+		case model::oculus_quest_2:
+			if (hand_id == XR_HAND_LEFT_EXT)
+				offset_angle = glm::radians(-90.0f);
+			else if (hand_id == XR_HAND_RIGHT_EXT)
+				offset_angle = glm::radians(90.0f);
+			break;
+		
+		default:
+			offset_angle = 0.0f;
+			break;
+	}
+
 	std::array<xr::hand_tracker::joint, XR_HAND_JOINT_COUNT_EXT> joints;
 	for (int i = 0; i < XR_HAND_JOINT_COUNT_EXT; i++)
 	{
-		switch (guess_model())
-		{
-			case model::meta_quest_3:
-			case model::meta_quest_pro:
-			case model::meta_quest_3s:
-			case model::oculus_quest:
-			case model::oculus_quest_2:
-				if (hand_id == XR_HAND_LEFT_EXT)
-					offset_angle = glm::radians(-90.0f);
-				else if (hand_id == XR_HAND_RIGHT_EXT)
-					offset_angle = glm::radians(90.0f);
-				break;
-			
-			default:
-				offset_angle = 0.0f;
-				break;
-		}
 
 		if (i >= XR_HAND_JOINT_THUMB_METACARPAL_EXT && i <= XR_HAND_JOINT_THUMB_TIP_EXT)
 		{

--- a/client/xr/hand_tracker.cpp
+++ b/client/xr/hand_tracker.cpp
@@ -36,25 +36,14 @@ XrResult xr::destroy_hand_tracker(XrHandTrackerEXT id)
 	return xrDestroyHandTrackerEXT(id);
 }
 
-xr::hand_tracker::hand_tracker(instance & inst, session & session, const XrHandTrackerCreateInfoEXT & info)
+xr::hand_tracker::hand_tracker(instance & inst, session & session, const XrHandTrackerCreateInfoEXT & info): 
+	hand_id(info.hand)
 {
-	hand_id = info.hand;
-	
-	if (hand_id == XrHandEXT::XR_HAND_LEFT_EXT)
-	{
-		offset_angle = glm::radians(-90.0f);
-	}
-	if (hand_id == XrHandEXT::XR_HAND_RIGHT_EXT)
-	{
-		offset_angle = glm::radians(90.0f);
-	}
-
 	static auto xrCreateHandTrackerEXT = inst.get_proc<PFN_xrCreateHandTrackerEXT>("xrCreateHandTrackerEXT");
 	assert(xrCreateHandTrackerEXT);
 	xrLocateHandJointsEXT = inst.get_proc<PFN_xrLocateHandJointsEXT>("xrLocateHandJointsEXT");
 	xrDestroyHandTrackerEXT = inst.get_proc<PFN_xrDestroyHandTrackerEXT>("xrDestroyHandTrackerEXT");
 	CHECK_XR(xrCreateHandTrackerEXT(session, &info, &id));
-
 
 }
 
@@ -93,6 +82,10 @@ std::optional<std::array<xr::hand_tracker::joint, XR_HAND_JOINT_COUNT_EXT>> xr::
 		return std::nullopt;
 	
 	
+
+	float offset_angle;
+
+	// check if we have a device that needs a thumb offset
 	switch (guess_model())
 	{
 		case model::meta_quest_3:

--- a/client/xr/hand_tracker.cpp
+++ b/client/xr/hand_tracker.cpp
@@ -41,7 +41,6 @@ xr::hand_tracker::hand_tracker(instance & inst, session & session, const XrHandT
 	xrLocateHandJointsEXT = inst.get_proc<PFN_xrLocateHandJointsEXT>("xrLocateHandJointsEXT");
 	xrDestroyHandTrackerEXT = inst.get_proc<PFN_xrDestroyHandTrackerEXT>("xrDestroyHandTrackerEXT");
 	CHECK_XR(xrCreateHandTrackerEXT(session, &info, &id));
-
 }
 
 std::optional<std::array<xr::hand_tracker::joint, XR_HAND_JOINT_COUNT_EXT>> xr::hand_tracker::locate(XrSpace space, XrTime time)
@@ -78,8 +77,6 @@ std::optional<std::array<xr::hand_tracker::joint, XR_HAND_JOINT_COUNT_EXT>> xr::
 	if (!locations.isActive)
 		return std::nullopt;
 	
-	
-
 	float offset_angle;
 
 	// check if we have a device that needs a thumb offset

--- a/client/xr/hand_tracker.cpp
+++ b/client/xr/hand_tracker.cpp
@@ -22,6 +22,12 @@
 #include "xr/instance.h"
 #include "xr/session.h"
 #include <cassert>
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/matrix_transform.inl>
+#include <glm/gtc/quaternion.hpp>
+#include <glm/gtx/quaternion.hpp>
+#include "hardware.h"
 
 static PFN_xrDestroyHandTrackerEXT xrDestroyHandTrackerEXT{};
 
@@ -32,11 +38,24 @@ XrResult xr::destroy_hand_tracker(XrHandTrackerEXT id)
 
 xr::hand_tracker::hand_tracker(instance & inst, session & session, const XrHandTrackerCreateInfoEXT & info)
 {
+	hand_id = info.hand;
+	
+	if (hand_id == XrHandEXT::XR_HAND_LEFT_EXT)
+	{
+		offset_angle = glm::radians(-90.0f);
+	}
+	if (hand_id == XrHandEXT::XR_HAND_RIGHT_EXT)
+	{
+		offset_angle= glm::radians(90.0f);
+	}
+
 	static auto xrCreateHandTrackerEXT = inst.get_proc<PFN_xrCreateHandTrackerEXT>("xrCreateHandTrackerEXT");
 	assert(xrCreateHandTrackerEXT);
 	xrLocateHandJointsEXT = inst.get_proc<PFN_xrLocateHandJointsEXT>("xrLocateHandJointsEXT");
 	xrDestroyHandTrackerEXT = inst.get_proc<PFN_xrDestroyHandTrackerEXT>("xrDestroyHandTrackerEXT");
 	CHECK_XR(xrCreateHandTrackerEXT(session, &info, &id));
+
+
 }
 
 std::optional<std::array<xr::hand_tracker::joint, XR_HAND_JOINT_COUNT_EXT>> xr::hand_tracker::locate(XrSpace space, XrTime time)
@@ -76,7 +95,48 @@ std::optional<std::array<xr::hand_tracker::joint, XR_HAND_JOINT_COUNT_EXT>> xr::
 	std::array<xr::hand_tracker::joint, XR_HAND_JOINT_COUNT_EXT> joints;
 	for (int i = 0; i < XR_HAND_JOINT_COUNT_EXT; i++)
 	{
-		joints[i] = {joints_pos[i], joints_vel[i]};
+		switch (guess_model())
+		{
+			case model::meta_quest_3:
+			case model::meta_quest_pro:
+			case model::meta_quest_3s:
+				if (hand_id == XR_HAND_LEFT_EXT)
+					offset_angle = glm::radians(-90.0f);
+				else if (hand_id == XR_HAND_RIGHT_EXT)
+					offset_angle = glm::radians(90.0f);
+				break;
+			
+			default:
+				offset_angle = 0.0f;
+				break;
+		}
+
+		if (i >= XR_HAND_JOINT_THUMB_METACARPAL_EXT && i <= XR_HAND_JOINT_THUMB_TIP_EXT)
+		{
+
+			// Need to convert the XrQuaternionf to a glm::quat to use glm::rotate
+			glm::quat q(
+				joints_pos[i].pose.orientation.w,
+				joints_pos[i].pose.orientation.x,
+				joints_pos[i].pose.orientation.y,
+				joints_pos[i].pose.orientation.z);
+
+			glm::quat offset_rotation = glm::rotate(q,offset_angle, glm::vec3(0,0,1));
+
+			joints_pos[i].pose.orientation = {
+				.x = offset_rotation.x,
+				.y = offset_rotation.y,
+				.z = offset_rotation.z,
+				.w = offset_rotation.w,
+			};
+
+			joints[i] = {joints_pos[i], joints_vel[i]};
+		}
+		else
+		{
+			joints[i] = {joints_pos[i], joints_vel[i]};
+		}
+
 	}
 
 	return joints;

--- a/client/xr/hand_tracker.cpp
+++ b/client/xr/hand_tracker.cpp
@@ -46,7 +46,7 @@ xr::hand_tracker::hand_tracker(instance & inst, session & session, const XrHandT
 	}
 	if (hand_id == XrHandEXT::XR_HAND_RIGHT_EXT)
 	{
-		offset_angle= glm::radians(90.0f);
+		offset_angle = glm::radians(90.0f);
 	}
 
 	static auto xrCreateHandTrackerEXT = inst.get_proc<PFN_xrCreateHandTrackerEXT>("xrCreateHandTrackerEXT");

--- a/client/xr/hand_tracker.h
+++ b/client/xr/hand_tracker.h
@@ -43,5 +43,8 @@ public:
 	std::optional<std::array<joint, XR_HAND_JOINT_COUNT_EXT>> locate(XrSpace space, XrTime time);
 
 	static bool check_flags(const std::array<joint, XR_HAND_JOINT_COUNT_EXT> & joints, XrSpaceLocationFlags position, XrSpaceVelocityFlags velocity);
+private:
+	XrHandEXT hand_id;
+	float offset_angle;
 };
 } // namespace xr

--- a/client/xr/hand_tracker.h
+++ b/client/xr/hand_tracker.h
@@ -33,7 +33,7 @@ XrResult destroy_hand_tracker(XrHandTrackerEXT);
 class hand_tracker : public utils::handle<XrHandTrackerEXT, destroy_hand_tracker>
 {
 	PFN_xrLocateHandJointsEXT xrLocateHandJointsEXT{};
-	
+
 public:
 	hand_tracker() = default;
 	hand_tracker(instance & inst, session & session, const XrHandTrackerCreateInfoEXT & info);
@@ -43,6 +43,7 @@ public:
 	std::optional<std::array<joint, XR_HAND_JOINT_COUNT_EXT>> locate(XrSpace space, XrTime time);
 
 	static bool check_flags(const std::array<joint, XR_HAND_JOINT_COUNT_EXT> & joints, XrSpaceLocationFlags position, XrSpaceVelocityFlags velocity);
+
 private:
 	XrHandEXT hand_id;
 };

--- a/client/xr/hand_tracker.h
+++ b/client/xr/hand_tracker.h
@@ -33,7 +33,7 @@ XrResult destroy_hand_tracker(XrHandTrackerEXT);
 class hand_tracker : public utils::handle<XrHandTrackerEXT, destroy_hand_tracker>
 {
 	PFN_xrLocateHandJointsEXT xrLocateHandJointsEXT{};
-
+	
 public:
 	hand_tracker() = default;
 	hand_tracker(instance & inst, session & session, const XrHandTrackerCreateInfoEXT & info);
@@ -44,6 +44,6 @@ public:
 
 	static bool check_flags(const std::array<joint, XR_HAND_JOINT_COUNT_EXT> & joints, XrSpaceLocationFlags position, XrSpaceVelocityFlags velocity);
 private:
-	const XrHandEXT hand_id;
+	XrHandEXT hand_id;
 };
 } // namespace xr

--- a/client/xr/hand_tracker.h
+++ b/client/xr/hand_tracker.h
@@ -44,7 +44,6 @@ public:
 
 	static bool check_flags(const std::array<joint, XR_HAND_JOINT_COUNT_EXT> & joints, XrSpaceLocationFlags position, XrSpaceVelocityFlags velocity);
 private:
-	XrHandEXT hand_id;
-	float offset_angle;
+	const XrHandEXT hand_id;
 };
 } // namespace xr


### PR DESCRIPTION
This should fix the thumbs being rotated by 90 degrees with hand tracking on meta headsets in #147

Hopefully the device checking was done correctly, let me know if there is anything there I need to fix.

This patch works on my Quest 3, but I have not tested on other headsets.