### PR TITLE
Client-side post-processing

### DIFF
--- a/.github/screenshot-script.txt
+++ b/.github/screenshot-script.txt
@@ -82,6 +82,17 @@ set right rotation 0.4 0 0 0.9
 sleep 1
 exec grim -g "0,0 2560x1440" ${LANG}/screenshot-04-settings.png
 
+# Post-processing
+set right direction -1.95 1.45 -1
+sleep 1
+set right trigger_value 1
+sleep 1
+set right trigger_value 0
+sleep 1
+set right rotation 0.4 0 0 0.9
+sleep 1
+exec grim -g "0,0 2560x1440" ${LANG}/screenshot-07-post-processing.png
+
 # About
 set right direction -2.4 0.45 -1
 sleep 1

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .cache/
 .gradle/
 _deps/
+.idea/
 
 build/
 build-*/

--- a/assets/licenses/SGSR
+++ b/assets/licenses/SGSR
@@ -1,0 +1,32 @@
+Snapdragon™ Game Super Resolution
+Copyright (c) 2023, Qualcomm Innovation Center, Inc. All rights reserved.
+
+https://github.com/SnapdragonStudios/snapdragon-gsr
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/client/application.cpp
+++ b/client/application.cpp
@@ -1044,6 +1044,7 @@ void application::initialize()
 	opt_extensions.push_back(XR_FB_COMPOSITION_LAYER_DEPTH_TEST_EXTENSION_NAME);
 	opt_extensions.push_back(XR_KHR_COMPOSITION_LAYER_COLOR_SCALE_BIAS_EXTENSION_NAME);
 	opt_extensions.push_back(XR_KHR_VISIBILITY_MASK_EXTENSION_NAME);
+	opt_extensions.push_back(XR_FB_COMPOSITION_LAYER_SETTINGS_EXTENSION_NAME);
 
 	for (const auto & i: interaction_profiles)
 	{
@@ -1118,6 +1119,12 @@ void application::initialize()
 		spdlog::info("    HTC lip tracking support: {}", (bool)htc_face_properties.supportLipFacialTracking);
 		htc_face_tracking_eye_supported = htc_face_properties.supportEyeFacialTracking;
 		htc_face_tracking_lip_supported = htc_face_properties.supportLipFacialTracking;
+	}
+
+	if (utils::contains(xr_extensions, XR_FB_COMPOSITION_LAYER_SETTINGS_EXTENSION_NAME))
+	{
+		spdlog::info("    OpenXR post-processing extension support: true");
+		openxr_post_processing_supported = true;
 	}
 
 	switch (xr_system_id.passthrough_supported())

--- a/client/application.h
+++ b/client/application.h
@@ -135,6 +135,8 @@ class application : public singleton<application>
 
 	bool eye_gaze_supported = false;
 
+	bool openxr_post_processing_supported = false;
+
 	bool session_running = false;
 	bool session_focused = false;
 	bool session_visible = false;
@@ -437,6 +439,11 @@ public:
 	static bool get_eye_gaze_supported()
 	{
 		return instance().eye_gaze_supported;
+	}
+
+	static bool get_openxr_post_processing_supported()
+	{
+		return instance().openxr_post_processing_supported;
 	}
 
 	static xr::hand_tracker & get_left_hand()

--- a/client/configuration.h
+++ b/client/configuration.h
@@ -25,6 +25,7 @@
 #include <map>
 #include <mutex>
 #include <optional>
+#include <simdjson.h>
 #include <string>
 
 namespace xr
@@ -53,6 +54,17 @@ public:
 	bool passthrough_enabled = false;
 	bool mic_unprocessed_audio = false;
 
+	// Snapdragon Game Super Resolution
+	struct sgsr_settings
+	{
+		bool enabled = false;
+		float upscaling_factor = 1.5;
+		bool use_edge_direction = true;
+		float edge_threshold = 4.0;
+		float edge_sharpness = 2.0;
+	};
+	sgsr_settings sgsr{};
+
 	std::string virtual_keyboard_layout = "QWERTY";
 
 	bool check_feature(feature f) const;
@@ -61,6 +73,8 @@ public:
 private:
 	mutable std::mutex mutex;
 	std::map<feature, bool> features;
+
+	void parse_sgsr_options(simdjson::simdjson_result<simdjson::dom::object> root);
 
 public:
 	configuration(xr::system &);

--- a/client/configuration.h
+++ b/client/configuration.h
@@ -65,6 +65,14 @@ public:
 	};
 	sgsr_settings sgsr{};
 
+	// XR_FB_composition_layer_settings extension flags
+	struct openxr_post_processing_settings
+	{
+		XrCompositionLayerSettingsFlagsFB super_sampling = 0;
+		XrCompositionLayerSettingsFlagsFB sharpening = 0;
+	};
+	openxr_post_processing_settings openxr_post_processing{};
+
 	std::string virtual_keyboard_layout = "QWERTY";
 
 	bool check_feature(feature f) const;
@@ -75,6 +83,7 @@ private:
 	std::map<feature, bool> features;
 
 	void parse_sgsr_options(simdjson::simdjson_result<simdjson::dom::object> root);
+	void parse_openxr_post_processing_options(simdjson::simdjson_result<simdjson::dom::object> root);
 
 public:
 	configuration(xr::system &);

--- a/client/scenes/lobby.h
+++ b/client/scenes/lobby.h
@@ -118,6 +118,7 @@ class lobby : public scene_impl<lobby>
 	{
 		server_list,
 		settings,
+		post_processing,
 #if WIVRN_CLIENT_DEBUG_MENU
 		debug,
 #endif
@@ -148,6 +149,7 @@ class lobby : public scene_impl<lobby>
 	void gui_server_list();
 	void gui_new_server();
 	void gui_settings();
+	void gui_post_processing();
 	void gui_debug();
 	void gui_about();
 	void gui_licenses();

--- a/client/scenes/stream.cpp
+++ b/client/scenes/stream.cpp
@@ -1148,8 +1148,17 @@ void scenes::stream::setup_reprojection_swapchain()
 
 	const uint32_t video_width = video_stream_description->width / view_count;
 	const uint32_t video_height = video_stream_description->height;
-	const uint32_t swapchain_width = video_width / video_stream_description->foveation[0].x.scale;
-	const uint32_t swapchain_height = video_height / video_stream_description->foveation[0].y.scale;
+	uint32_t swapchain_width = video_width / video_stream_description->foveation[0].x.scale;
+	uint32_t swapchain_height = video_height / video_stream_description->foveation[0].y.scale;
+
+	const configuration::sgsr_settings sgsr = application::get_config().sgsr;
+	if (sgsr.enabled)
+	{
+		const float upscaling_factor = sgsr.upscaling_factor;
+		spdlog::info("Using SGSR with an upscale factor of {}", upscaling_factor);
+		swapchain_width *= upscaling_factor;
+		swapchain_height *= upscaling_factor;
+	}
 
 	auto views = system.view_configuration_views(viewconfig);
 

--- a/client/scenes/stream.cpp
+++ b/client/scenes/stream.cpp
@@ -924,6 +924,17 @@ void scenes::stream::render(const XrFrameState & frame_state)
 	        .views = layer_view.data(),
 	};
 
+	XrCompositionLayerSettingsFB settings;
+	const configuration::openxr_post_processing_settings openxr_post_processing = application::get_config().openxr_post_processing;
+	if ((openxr_post_processing.sharpening | openxr_post_processing.super_sampling) > 0)
+	{
+		settings = {
+		        .type = XR_TYPE_COMPOSITION_LAYER_SETTINGS_FB,
+		        .layerFlags = openxr_post_processing.sharpening | openxr_post_processing.super_sampling,
+		};
+		layer.next = &settings;
+	}
+
 	std::vector<XrCompositionLayerQuad> imgui_layers;
 	if (imgui_ctx)
 	{

--- a/client/shaders/reprojection.glsl
+++ b/client/shaders/reprojection.glsl
@@ -19,6 +19,8 @@
 
 #version 450
 
+#ifdef VERT_SHADER
+
 layout (constant_id = 0) const bool use_foveation_x = false;
 layout (constant_id = 1) const bool use_foveation_y = false;
 layout (constant_id = 2) const int nb_x = 64;
@@ -32,6 +34,12 @@ layout(set = 0, binding = 1) uniform UniformBufferObject
 	vec2 xc;
 }
 ubo;
+
+layout(location = 0) out vec2 outUV;
+
+vec2 positions[6] = vec2[](
+	vec2(0, 0), vec2(1, 0), vec2(0, 1),
+	vec2(1, 0), vec2(0, 1), vec2(1, 1));
 
 vec2 unfoveate(vec2 uv)
 {
@@ -54,14 +62,6 @@ vec2 unfoveate(vec2 uv)
 	return uv;
 }
 
-#ifdef VERT_SHADER
-
-vec2 positions[6] = vec2[](
-	vec2(0, 0), vec2(1, 0), vec2(0, 1),
-	vec2(1, 0), vec2(0, 1), vec2(1, 1));
-
-layout(location = 0) out vec2 outUV;
-
 void main()
 {
 	vec2 quad_size = 1 / vec2(nb_x, nb_y);
@@ -75,6 +75,7 @@ void main()
 #endif
 
 #ifdef FRAG_SHADER
+
 layout(set = 0, binding = 0) uniform sampler2D texSampler;
 
 layout(location = 0) in vec2 inUV;
@@ -83,8 +84,7 @@ layout(location = 0) out vec4 outColor;
 
 void main()
 {
-	outColor = texture(texSampler, inUV).rgba;
-
+    outColor = texture(texSampler, inUV).rgba;
 }
-#endif
 
+#endif

--- a/client/shaders/reprojection_sgsr.frag.glsl
+++ b/client/shaders/reprojection_sgsr.frag.glsl
@@ -1,0 +1,179 @@
+/*
+ * Snapdragon™ Game Super Resolution
+ * Copyright (c) 2023, Qualcomm Innovation Center, Inc. All rights reserved.
+ *
+ * https://github.com/SnapdragonStudios/snapdragon-gsr
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#version 450
+
+precision mediump float;
+precision highp int;
+
+#define OperationMode 1
+
+layout (constant_id = 0) const bool use_edge_direction = true;
+layout (constant_id = 1) const float edge_threshold = 4.0/255.0;
+layout (constant_id = 2) const float edge_sharpness = 2.0;
+
+layout(set = 0, binding = 0) uniform mediump sampler2D texSampler;
+
+layout(location = 0) in highp vec2 inUV;
+
+layout(location = 0) out vec4 outColor;
+
+float fastLanczos2(float x)
+{
+	float wA = x-4.0;
+	float wB = x*wA-wA;
+	wA *= wA;
+	return wB*wA;
+}
+
+vec2 weightY(float dx, float dy, float c, vec3 data)
+{
+	float std = data.x;
+	vec2 dir = data.yz;
+
+	float edgeDis = ((dx*dir.y)+(dy*dir.x));
+	float x = (((dx*dx)+(dy*dy))+((edgeDis*edgeDis)*((clamp(((c*c)*std),0.0,1.0)*0.7)+-1.0)));
+
+	float w = fastLanczos2(x);
+	return vec2(w, w * c);	
+}
+
+vec2 weightYned(float dx, float dy, float c, float std)
+{
+	float x = ((dx*dx)+(dy* dy))* 0.55 + clamp(abs(c)*std, 0.0, 1.0);
+
+	float w = fastLanczos2(x);
+	return vec2(w, w * c);	
+}
+
+vec2 edgeDirection(vec4 left, vec4 right)
+{
+	vec2 dir;
+	float RxLz = (right.x + (-left.z));
+	float RwLy = (right.w + (-left.y));
+	vec2 delta;
+	delta.x = (RxLz + RwLy);
+	delta.y = (RxLz + (-RwLy));
+	float lengthInv = inversesqrt((delta.x * delta.x+ 3.075740e-05) + (delta.y * delta.y));
+	dir.x = (delta.x * lengthInv);
+	dir.y = (delta.y * lengthInv);
+	return dir;
+}
+
+void main()
+{
+	vec4 color = textureLod(texSampler,inUV,0.0).xyzw;
+	float alpha = color.a;
+
+	if (OperationMode == 1)
+		color.a = 0.0;
+
+	if (OperationMode != 4)
+	{
+		vec2 dim = textureSize(texSampler, 0);
+		vec4 viewportInfo = vec4(1/dim.x, 1/dim.y, dim.x, dim.y);
+
+		highp vec2 imgCoord = ((inUV.xy*viewportInfo.zw)+vec2(-0.5,0.5));
+		highp vec2 imgCoordPixel = floor(imgCoord);
+		highp vec2 coord = (imgCoordPixel*viewportInfo.xy);
+		vec2 pl = (imgCoord+(-imgCoordPixel));
+		vec4 left = textureGather(texSampler,coord, OperationMode);
+
+		float edgeVote = abs(left.z - left.y) + abs(color[OperationMode] - left.y)  + abs(color[OperationMode] - left.z) ;
+		if(edgeVote > edge_threshold)
+		{
+			coord.x += viewportInfo.x;
+
+			vec4 right = textureGather(texSampler,coord + vec2(viewportInfo.x, 0.0), OperationMode);
+			vec4 upDown;
+			upDown.xy = textureGather(texSampler,coord + vec2(0.0, -viewportInfo.y),OperationMode).wz;
+			upDown.zw  = textureGather(texSampler,coord + vec2(0.0, viewportInfo.y), OperationMode).yx;
+
+			float mean = (left.y+left.z+right.x+right.w)*0.25;
+			left = left - vec4(mean);
+			right = right - vec4(mean);
+			upDown = upDown - vec4(mean);
+			color.w =color[OperationMode] - mean;
+
+			float sum = (((((abs(left.x)+abs(left.y))+abs(left.z))+abs(left.w))+(((abs(right.x)+abs(right.y))+abs(right.z))+abs(right.w)))+(((abs(upDown.x)+abs(upDown.y))+abs(upDown.z))+abs(upDown.w)));
+			float sumMean = 1.014185e+01/sum;
+			float std = (sumMean*sumMean);
+
+			vec2 aWY;
+			if (use_edge_direction) {
+				vec3 data = vec3(std, edgeDirection(left, right));
+				aWY = weightY(pl.x, pl.y+1.0, upDown.x,data);
+				aWY += weightY(pl.x-1.0, pl.y+1.0, upDown.y,data);
+				aWY += weightY(pl.x-1.0, pl.y-2.0, upDown.z,data);
+				aWY += weightY(pl.x, pl.y-2.0, upDown.w,data);
+				aWY += weightY(pl.x+1.0, pl.y-1.0, left.x,data);
+				aWY += weightY(pl.x, pl.y-1.0, left.y,data);
+				aWY += weightY(pl.x, pl.y, left.z,data);
+				aWY += weightY(pl.x+1.0, pl.y, left.w,data);
+				aWY += weightY(pl.x-1.0, pl.y-1.0, right.x,data);
+				aWY += weightY(pl.x-2.0, pl.y-1.0, right.y,data);
+				aWY += weightY(pl.x-2.0, pl.y, right.z,data);
+				aWY += weightY(pl.x-1.0, pl.y, right.w,data);
+			} else {
+				aWY = weightYned(pl.x, pl.y+1.0, upDown.x,std);
+				aWY += weightYned(pl.x-1.0, pl.y+1.0, upDown.y,std);
+				aWY += weightYned(pl.x-1.0, pl.y-2.0, upDown.z,std);
+				aWY += weightYned(pl.x, pl.y-2.0, upDown.w,std);
+				aWY += weightYned(pl.x+1.0, pl.y-1.0, left.x,std);
+				aWY += weightYned(pl.x, pl.y-1.0, left.y,std);
+				aWY += weightYned(pl.x, pl.y, left.z,std);
+				aWY += weightYned(pl.x+1.0, pl.y, left.w,std);
+				aWY += weightYned(pl.x-1.0, pl.y-1.0, right.x,std);
+				aWY += weightYned(pl.x-2.0, pl.y-1.0, right.y,std);
+				aWY += weightYned(pl.x-2.0, pl.y, right.z,std);
+				aWY += weightYned(pl.x-1.0, pl.y, right.w,std);
+			}
+
+			float finalY = aWY.y/aWY.x;
+			float maxY = max(max(left.y,left.z),max(right.x,right.w));
+			float minY = min(min(left.y,left.z),min(right.x,right.w));
+			float deltaY = clamp(edge_sharpness*finalY, minY, maxY) -color.w;
+
+			//smooth high contrast input
+			deltaY = clamp(deltaY, -23.0 / 255.0, 23.0 / 255.0);
+
+			color.x = clamp((color.x+deltaY),0.0,1.0);
+			color.y = clamp((color.y+deltaY),0.0,1.0);
+			color.z = clamp((color.z+deltaY),0.0,1.0);
+		}
+	}
+
+    outColor = vec4(color.rgb, alpha);
+}

--- a/locale/fr/wivrn-dashboard.po
+++ b/locale/fr/wivrn-dashboard.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: WiVRn-dashboard\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-14 16:29+0100\n"
+"POT-Creation-Date: 2025-03-25 21:15+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Guillaume Meunier <guillaume.meunier@centraliens.net>\n"
 "Language: French\n"
@@ -11,47 +11,47 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: dashboard/apk_installer.cpp:175
+#: dashboard/apk_installer.cpp:167
 #, kde-format
 msgid "Downloading APK: %1 MB / %2 MB"
 msgstr "Téléchargement de l'APK : %1 MB / %2 MB"
 
-#: dashboard/apk_installer.cpp:177
+#: dashboard/apk_installer.cpp:169
 #, kde-format
 msgid "Downloading APK: %1 MB"
 msgstr "Téléchargement de l'APK : %1 MB"
 
-#: dashboard/apk_installer.cpp:186
+#: dashboard/apk_installer.cpp:178
 #, kde-format
 msgid "Download cancelled"
 msgstr "Téléchargement annulé"
 
-#: dashboard/apk_installer.cpp:202
+#: dashboard/apk_installer.cpp:194
 #, kde-format
 msgid "Cannot download APK: %1"
 msgstr "Impossible de télécharger l'APK : %1"
 
-#: dashboard/apk_installer.cpp:225
+#: dashboard/apk_installer.cpp:217
 #, kde-format
 msgid "Installing APK"
 msgstr "Installation de l'APK"
 
-#: dashboard/apk_installer.cpp:229
+#: dashboard/apk_installer.cpp:221
 #, kde-format
 msgid "adb failed to start: %1"
 msgstr "adb n'a pas pu démarrer : %1"
 
-#: dashboard/apk_installer.cpp:239
+#: dashboard/apk_installer.cpp:231
 #, kde-format
 msgid "adb exited abnormally: %1"
 msgstr "adb a quitté de façon anormale : %1"
 
-#: dashboard/apk_installer.cpp:247
+#: dashboard/apk_installer.cpp:239
 #, kde-format
 msgid "The 'adb install' command failed: exit code %1"
 msgstr "La commande 'adb install' a échoué : code de retour %1"
 
-#: dashboard/apk_installer.cpp:252
+#: dashboard/apk_installer.cpp:244
 #, kde-format
 msgid "Installation successful"
 msgstr "Installation réussie"
@@ -592,9 +592,9 @@ msgid ""
 "</p><ul><li>The headset app version is in the \"About\" page</li><li>The "
 "server version is <b>%1</b></li></ul>"
 msgstr ""
-"<p>La version de l'application sur le casque et le serveur doivent correspondre."
-"</p><ul><li>La version de l'application sur le casque est dans la page « À propos »"
-"</li><li>La version du serveur est <b>%1</b></li></ul>"
+"<p>La version de l'application sur le casque et le serveur doivent "
+"correspondre.</p><ul><li>La version de l'application sur le casque est dans "
+"la page « À propos »</li><li>La version du serveur est <b>%1</b></li></ul>"
 
 #: dashboard/qml/TroubleshootPage.qml:32
 #, kde-format

--- a/locale/fr/wivrn.po
+++ b/locale/fr/wivrn.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: WiVRn 0.15\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-09 23:49+0200\n"
+"POT-Creation-Date: 2025-04-13 16:50+0200\n"
 "PO-Revision-Date: 2024-05-20 13:00+0200\n"
 "Last-Translator: Guillaume Meunier <guillaume.meunier@centraliens.net>\n"
 "Language: French\n"
@@ -38,15 +38,30 @@ msgstr "Impossible de se connecter à {} ({}): {}"
 msgid "Waiting for connection"
 msgstr "Attente de connexion"
 
-#: client/scenes/lobby_gui.cpp:174 client/scenes/lobby_gui.cpp:367
+#: client/scenes/lobby_gui.cpp:131
+msgctxt "openxr_post_processing"
+msgid "Normal"
+msgstr "Normal"
+
+#: client/scenes/lobby_gui.cpp:134
+msgctxt "openxr_post_processing"
+msgid "Quality"
+msgstr "Qualité"
+
+#: client/scenes/lobby_gui.cpp:136
+msgctxt "openxr_post_processing"
+msgid "Disabled"
+msgstr "Désactivé"
+
+#: client/scenes/lobby_gui.cpp:197 client/scenes/lobby_gui.cpp:390
 msgid "Cancel"
 msgstr "Annuler"
 
-#: client/scenes/lobby_gui.cpp:180
+#: client/scenes/lobby_gui.cpp:203
 msgid "Video stream interrupted"
 msgstr "Flux vidéo interrompu"
 
-#: client/scenes/lobby_gui.cpp:182
+#: client/scenes/lobby_gui.cpp:205
 msgid ""
 "Connection ready\n"
 "Start a VR application on your computer"
@@ -54,7 +69,7 @@ msgstr ""
 "Connexion prête\n"
 "Démarrez une application VR sur l'ordinateur"
 
-#: client/scenes/lobby_gui.cpp:184
+#: client/scenes/lobby_gui.cpp:207
 #, c++-format
 msgid ""
 "Connection ready\n"
@@ -63,48 +78,48 @@ msgstr ""
 "Connexion prête\n"
 "Démarrez une application VR sur {}"
 
-#: client/scenes/lobby_gui.cpp:197
+#: client/scenes/lobby_gui.cpp:220
 msgid "Close"
 msgstr "Fermer"
 
-#: client/scenes/lobby_gui.cpp:203
+#: client/scenes/lobby_gui.cpp:226
 msgid "Connection"
 msgstr "Connexion en cours"
 
-#: client/scenes/lobby_gui.cpp:205
+#: client/scenes/lobby_gui.cpp:228
 #, c++-format
 msgid "Connection to {}"
 msgstr "Connexion à {}"
 
-#: client/scenes/lobby_gui.cpp:235
+#: client/scenes/lobby_gui.cpp:258
 msgid "PIN"
 msgstr "Code PIN"
 
-#: client/scenes/lobby_gui.cpp:257
+#: client/scenes/lobby_gui.cpp:280
 msgid "Input the PIN displayed on the dashboard"
 msgstr "Entrez le code PIN affiché sur le tableau de bord"
 
-#: client/scenes/lobby_gui.cpp:332
+#: client/scenes/lobby_gui.cpp:355
 msgid "Name"
 msgstr "Nom"
 
-#: client/scenes/lobby_gui.cpp:343
+#: client/scenes/lobby_gui.cpp:366
 msgid "Address"
 msgstr "Adresse"
 
-#: client/scenes/lobby_gui.cpp:352
+#: client/scenes/lobby_gui.cpp:375
 msgid "Port"
 msgstr "Port"
 
-#: client/scenes/lobby_gui.cpp:360
+#: client/scenes/lobby_gui.cpp:383
 msgid "TCP only"
 msgstr "TCP seulement"
 
-#: client/scenes/lobby_gui.cpp:381
+#: client/scenes/lobby_gui.cpp:404
 msgid "Save"
 msgstr "Enregistrer"
 
-#: client/scenes/lobby_gui.cpp:434
+#: client/scenes/lobby_gui.cpp:457
 msgid ""
 "Start a WiVRn server on your\n"
 "local network"
@@ -112,32 +127,32 @@ msgstr ""
 "Démarrez un serveur WiVRn sur\n"
 "le réseau local"
 
-#: client/scenes/lobby_gui.cpp:466
+#: client/scenes/lobby_gui.cpp:489
 msgid "Autoconnect"
 msgstr "Autoconnexion"
 
-#: client/scenes/lobby_gui.cpp:492
+#: client/scenes/lobby_gui.cpp:515
 msgid "Connect"
 msgstr "Connexion"
 
-#: client/scenes/lobby_gui.cpp:502
+#: client/scenes/lobby_gui.cpp:525
 msgid "Incompatible server version"
 msgstr "Version du serveur incompatible"
 
-#: client/scenes/lobby_gui.cpp:504
+#: client/scenes/lobby_gui.cpp:527
 msgid "Server not available"
 msgstr "Serveur non disponible"
 
-#: client/scenes/lobby_gui.cpp:590
+#: client/scenes/lobby_gui.cpp:613
 msgid "Refresh rate"
 msgstr "Taux de rafraichissement"
 
-#: client/scenes/lobby_gui.cpp:590 client/scenes/lobby_gui.cpp:592
+#: client/scenes/lobby_gui.cpp:613 client/scenes/lobby_gui.cpp:615
 msgctxt "automatic refresh rate"
 msgid "Automatic"
 msgstr "Automatique"
 
-#: client/scenes/lobby_gui.cpp:599
+#: client/scenes/lobby_gui.cpp:622
 msgid ""
 "Select refresh rate based on measured application performance.\n"
 "May cause flicker when a change happens."
@@ -146,144 +161,222 @@ msgstr ""
 "des performances mesurées.\n"
 "Peut causer des clignotements lors du changement de fréquence."
 
-#: client/scenes/lobby_gui.cpp:616
+#: client/scenes/lobby_gui.cpp:639
 msgid "Minimum refresh rate"
 msgstr "Taux minimal"
 
-#: client/scenes/lobby_gui.cpp:638
+#: client/scenes/lobby_gui.cpp:662
 msgid "Resolution scale"
 msgstr "Échelle"
 
-#: client/scenes/lobby_gui.cpp:638
+#: client/scenes/lobby_gui.cpp:666 client/scenes/lobby_gui.cpp:915
 #, c-format, c++-format
 msgid "%d%% - {}x{} per eye"
 msgstr "%d%% - {}x{} par œil"
 
-#: client/scenes/lobby_gui.cpp:648
+#: client/scenes/lobby_gui.cpp:677 client/scenes/lobby_gui.cpp:926
 #, c++-format
 msgid "Resolution larger than {}x{} may not be supported by the headset"
 msgstr "Les résolutions plus grandes que {}x{} pourraient ne pas fonctionner"
 
-#: client/scenes/lobby_gui.cpp:654
+#: client/scenes/lobby_gui.cpp:683
 msgid "Enable microphone"
 msgstr "Activer le micro"
 
-#: client/scenes/lobby_gui.cpp:664
+#: client/scenes/lobby_gui.cpp:693
 msgid "Unprocessed Microphone Audio"
 msgstr "Utiliser les données brutes du micro"
 
-#: client/scenes/lobby_gui.cpp:670
+#: client/scenes/lobby_gui.cpp:699
 msgid "Force disable audio filters, such as noise cancellation"
 msgstr "Désactive les traitements tels que la suppression du bruit"
 
-#: client/scenes/lobby_gui.cpp:677
+#: client/scenes/lobby_gui.cpp:706
 msgid "Enable hand tracking"
 msgstr "Activer le suivi des mains"
 
-#: client/scenes/lobby_gui.cpp:684 client/scenes/lobby_gui.cpp:697
-#: client/scenes/lobby_gui.cpp:710 client/scenes/lobby_gui.cpp:722
+#: client/scenes/lobby_gui.cpp:713 client/scenes/lobby_gui.cpp:726
+#: client/scenes/lobby_gui.cpp:739 client/scenes/lobby_gui.cpp:751
 msgid "This feature is not supported by your headset"
 msgstr "Cette fonctionnalité n'est pas supportée par le casque"
 
-#: client/scenes/lobby_gui.cpp:690
+#: client/scenes/lobby_gui.cpp:719
 msgid "Enable eye tracking"
 msgstr "Activer le suivi des yeux"
 
-#: client/scenes/lobby_gui.cpp:703
+#: client/scenes/lobby_gui.cpp:732
 msgid "Enable face tracking"
 msgstr "Activer le suivi du visage"
 
-#: client/scenes/lobby_gui.cpp:715
+#: client/scenes/lobby_gui.cpp:744
 msgid "Enable video passthrough in lobby"
 msgstr "Activer la vue réelle dans l'accueil"
 
-#: client/scenes/lobby_gui.cpp:725
+#: client/scenes/lobby_gui.cpp:754
 msgid "Show performance metrics"
 msgstr "Afficher les métriques de performances"
 
-#: client/scenes/lobby_gui.cpp:729
+#: client/scenes/lobby_gui.cpp:758
 msgid "Overlay can be toggled by pressing both thumbsticks"
 msgstr "L'affichage peut être basculé en appuyant sur les deux joysticks"
 
-#: client/scenes/lobby_gui.cpp:759 client/scenes/lobby_gui.cpp:767
+#: client/scenes/lobby_gui.cpp:788 client/scenes/lobby_gui.cpp:796
 #: client/scenes/stream_stats.cpp:159
 msgid "CPU time"
 msgstr "Temps CPU"
 
-#: client/scenes/lobby_gui.cpp:763
+#: client/scenes/lobby_gui.cpp:792
 msgid "CPU time [ms]"
 msgstr "Temps CPU [ms]"
 
-#: client/scenes/lobby_gui.cpp:773 client/scenes/lobby_gui.cpp:781
+#: client/scenes/lobby_gui.cpp:802 client/scenes/lobby_gui.cpp:810
 #: client/scenes/stream_stats.cpp:161
 msgid "GPU time"
 msgstr "Temps GPU"
 
-#: client/scenes/lobby_gui.cpp:777
+#: client/scenes/lobby_gui.cpp:806
 msgid "GPU time [ms]"
 msgstr "Temps GPU [ms]"
 
-#: client/scenes/lobby_gui.cpp:867 client/scenes/lobby_gui.cpp:1506
+#: client/scenes/lobby_gui.cpp:825
+msgid "OpenXR post-processing"
+msgstr "Post-traitement OpenXR"
+
+#: client/scenes/lobby_gui.cpp:829
+msgid "Supersampling"
+msgstr "Suréchantillonnage"
+
+#: client/scenes/lobby_gui.cpp:849
+msgid ""
+"Reduce flicker for high contrast edges.\n"
+"Useful when the input resolution is high compared to the headset display"
+msgstr ""
+"Réduit le scintillement des contours à haut contraste.\n"
+"Utile quand la résolution d’entrée est haute comparée à l’écran du casque"
+
+#: client/scenes/lobby_gui.cpp:854
+msgid "Sharpening"
+msgstr "Affinage de netteté"
+
+#: client/scenes/lobby_gui.cpp:874
+msgid ""
+"Improve clarity of high contrast edges and counteract blur.\n"
+"Useful when the input resolution is low compared to the headset display"
+msgstr ""
+"Améliore la clarté des contours à haut contraste et réduit le flou.\n"
+"Utile quand la résolution d’entrée est basse comparée à l’écran du casque"
+
+#: client/scenes/lobby_gui.cpp:883
+msgid "Enable Snapdragon Game Super Resolution"
+msgstr "Activer Snapdragon Game Super Resolution"
+
+#: client/scenes/lobby_gui.cpp:891
+msgid ""
+"On this headset, this setting has been fully superseded by the native "
+"Sharpening setting above.\n"
+"Only enable if you know what you’re doing."
+msgstr ""
+"Sur ce casque, ce paramètre a été supplanté par le réglage natif d’affinage "
+"de netteté ci-dessus.\n"
+"N’activer que si vous savez ce que vous faites."
+
+#: client/scenes/lobby_gui.cpp:893
+msgid ""
+"Client-side upscaling and sharpening, adds a performance cost on the headset"
+msgstr ""
+"Mise à l’échelle et affinage de netteté, ajoute un coût en performances pour "
+"le casque"
+
+#: client/scenes/lobby_gui.cpp:911
+msgid "Upscaling factor"
+msgstr "Échelle"
+
+#: client/scenes/lobby_gui.cpp:930
+msgid "Use edge direction"
+msgstr "Utiliser la direction de contours"
+
+#: client/scenes/lobby_gui.cpp:936
+msgid "Adds an additional performance cost"
+msgstr "Ajoute un coût additionnel en performances"
+
+#: client/scenes/lobby_gui.cpp:941
+msgid "Edge threshold"
+msgstr "Seuil de contour"
+
+#: client/scenes/lobby_gui.cpp:948 client/scenes/lobby_gui.cpp:957
+#, c++-format
+msgid "Recommended: {:.1f}"
+msgstr "Recommandé : {:.1f}"
+
+#: client/scenes/lobby_gui.cpp:951
+msgid "Edge sharpness"
+msgstr "Netteté de contour"
+
+#: client/scenes/lobby_gui.cpp:1045 client/scenes/lobby_gui.cpp:1691
 msgid "Licenses"
 msgstr "Licences"
 
-#: client/scenes/lobby_gui.cpp:1206
+#: client/scenes/lobby_gui.cpp:1384
 msgid "Microphone is enabled"
 msgstr "Le micro est activé"
 
-#: client/scenes/lobby_gui.cpp:1207
+#: client/scenes/lobby_gui.cpp:1385
 msgid "Microphone is disabled"
 msgstr "Le micro est désactivé"
 
-#: client/scenes/lobby_gui.cpp:1216
+#: client/scenes/lobby_gui.cpp:1394
 msgid "Hand tracking is enabled"
 msgstr "Le suivi des mains est activé"
 
-#: client/scenes/lobby_gui.cpp:1217
+#: client/scenes/lobby_gui.cpp:1395
 msgid "Hand tracking is disabled"
 msgstr "Le suivi des mains est désactivé"
 
-#: client/scenes/lobby_gui.cpp:1226
+#: client/scenes/lobby_gui.cpp:1404
 msgid "Eye tracking is enabled"
 msgstr "Le suivi des yeux est activé"
 
-#: client/scenes/lobby_gui.cpp:1227
+#: client/scenes/lobby_gui.cpp:1405
 msgid "Eye tracking is disabled"
 msgstr "Le suivi des yeux est désactivé"
 
-#: client/scenes/lobby_gui.cpp:1237 client/scenes/lobby_gui.cpp:1248
+#: client/scenes/lobby_gui.cpp:1415 client/scenes/lobby_gui.cpp:1426
 msgid "Face tracking is enabled"
 msgstr "Le suivi du visage est activé"
 
-#: client/scenes/lobby_gui.cpp:1238 client/scenes/lobby_gui.cpp:1249
+#: client/scenes/lobby_gui.cpp:1416 client/scenes/lobby_gui.cpp:1427
 msgid "Face tracking is disabled"
 msgstr "Le suivi du visage est désactivé"
 
-#: client/scenes/lobby_gui.cpp:1266
+#: client/scenes/lobby_gui.cpp:1444
 msgid "Add server"
 msgstr "Ajouter un serveur"
 
-#: client/scenes/lobby_gui.cpp:1491
+#: client/scenes/lobby_gui.cpp:1673
 msgid "Server list"
 msgstr "Serveurs"
 
-#: client/scenes/lobby_gui.cpp:1494
+#: client/scenes/lobby_gui.cpp:1676
 msgid "Settings"
 msgstr "Paramètres"
 
-#: client/scenes/lobby_gui.cpp:1498
+#: client/scenes/lobby_gui.cpp:1679
+msgid "Post-processing"
+msgstr "Post-traitement"
+
+#: client/scenes/lobby_gui.cpp:1683
 msgid "Debug"
 msgstr "Debug"
 
-#: client/scenes/lobby_gui.cpp:1503
+#: client/scenes/lobby_gui.cpp:1688
 msgid "About"
 msgstr "À propos"
 
-#: client/scenes/lobby_gui.cpp:1509
+#: client/scenes/lobby_gui.cpp:1694
 msgid "Exit"
 msgstr "Quitter"
 
-#: client/scenes/lobby_gui.cpp:1523
+#: client/scenes/lobby_gui.cpp:1708
 msgid ""
 "Press A or X or put your palm up\n"
 "to move the main window"
@@ -291,7 +384,7 @@ msgstr ""
 "Appuyez sur A ou X ou placez votre paume\n"
 "vers le haut pour déplacer la fenêtre principale"
 
-#: client/scenes/lobby_gui.cpp:1525
+#: client/scenes/lobby_gui.cpp:1710
 msgid "Press A or X to move the main window"
 msgstr ""
 "Appuyez sur A ou X pour\n"


### PR DESCRIPTION
This is an early working version of the [Snapdragon Game Super Resolution V1 algorithm](https://github.com/SnapdragonStudios/snapdragon-gsr/tree/main/sgsr/v1), implemented within the reprojection shader.

I added toggles and sliders in the client settings to enable it and tweak its behavior (disabled by default, of course).
It seems to be working, in the sense that the result sent to the display is indeed of higher resolution, and sharpened with various results depending on the sliders.
From my initial testing, visual fidelity improvements are arguably present (slight sharpening) but difficult to notice. However, it might be due to me not having tried the right combinations of settings yet.

Although I am a programmer by trade, this is my very first time working with graphics programming, so I will gladly take your criticisms and advice!