### PR TITLE
update ja local

### DIFF
--- a/locale/ja/wivrn-dashboard.po
+++ b/locale/ja/wivrn-dashboard.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: WiVRn-dashboard\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-10 07:14+0900\n"
+"POT-Creation-Date: 2025-04-20 17:32+0900\n"
 "PO-Revision-Date: 2025-04-10 07:14+0900\n"
 "Last-Translator: Mitsuami Megane <hello@mitsua.me>\n"
 "Language: Japanese\n"
@@ -95,8 +95,8 @@ msgid ""
 "master/docs/building.md#client-headset\">documentation</a> to build your own "
 "client."
 msgstr ""
-"自分でクライエントをビルドするには、<a href=\"https://github.com/WiVRn/WiVRn/blob/"
-"master/docs/building.md#client-headset\">マニュアル</a>をご覧ください。"
+"自分でクライエントをビルドするには、<a href=\"https://github.com/WiVRn/WiVRn/"
+"blob/master/docs/building.md#client-headset\">マニュアル</a>をご覧ください。"
 
 #: dashboard/qml/ApkInstallPage.qml:65 dashboard/qml/HeadsetStatsPage.qml:36
 #: dashboard/qml/HeadsetsPage.qml:183 dashboard/qml/TroubleshootPage.qml:59
@@ -136,24 +136,28 @@ msgid "Headsets"
 msgstr "HMD"
 
 #: dashboard/qml/HeadsetsPage.qml:29
-#, kde-format
+#, fuzzy, kde-format
 msgid "Last connection: %1 second ago"
-msgstr "前回の接続: %1 秒前"
+msgid_plural "Last connection: %1 seconds ago"
+msgstr[0] "前回の接続: %1 秒前"
 
 #: dashboard/qml/HeadsetsPage.qml:31
-#, kde-format
+#, fuzzy, kde-format
 msgid "Last connection: %1 minute ago"
-msgstr "前回の接続: %1 分前"
+msgid_plural "Last connection: %1 minutes ago"
+msgstr[0] "前回の接続: %1 分前"
 
 #: dashboard/qml/HeadsetsPage.qml:33
-#, kde-format
+#, fuzzy, kde-format
 msgid "Last connection: %1 hour ago"
-msgstr "前回の接続: %1 時間前"
+msgid_plural "Last connection: %1 hours ago"
+msgstr[0] "前回の接続: %1 時間前"
 
 #: dashboard/qml/HeadsetsPage.qml:35
-#, kde-format
+#, fuzzy, kde-format
 msgid "Last connection: %1 day ago"
-msgstr "前回の接続: %1 日前"
+msgid_plural "Last connection: %1 days ago"
+msgstr[0] "前回の接続: %1 日前"
 
 #: dashboard/qml/HeadsetsPage.qml:40
 #, kde-format
@@ -237,7 +241,9 @@ msgstr "今すぐ再起動する"
 #, kde-format
 msgid ""
 "NVIDIA GPUs require at least driver version 565.77, current version is %1"
-msgstr "NVIDIAの場合は、GPUドライバー・バージョン565.77以上が必要です。現バージョン：%1"
+msgstr ""
+"NVIDIAの場合は、GPUドライバー・バージョン565.77以上が必要です。現バージョン："
+"%1"
 
 #: dashboard/qml/Main.qml:142
 #, kde-format
@@ -316,7 +322,7 @@ msgstr "セットアップウィザード"
 msgid "Install the app"
 msgstr "アプリをインストール"
 
-#: dashboard/qml/Main.qml:349 dashboard/qml/SettingsPage.qml:12
+#: dashboard/qml/Main.qml:349 dashboard/qml/SettingsPage.qml:14
 #, kde-format
 msgid "Settings"
 msgstr "設定"
@@ -344,23 +350,23 @@ msgctxt "browse a file to choose the application to start"
 msgid "Browse"
 msgstr "検索"
 
-#: dashboard/qml/SettingsPage.qml:31
+#: dashboard/qml/SettingsPage.qml:40
 #, kde-format
 msgctxt "automatic foveation setup"
 msgid "Manual foveation"
 msgstr "マニュアル・フォビエーション"
 
-#: dashboard/qml/SettingsPage.qml:37
+#: dashboard/qml/SettingsPage.qml:46
 #, kde-format
 msgid "Foveation strength:"
 msgstr "フォビエーションの強さ"
 
-#: dashboard/qml/SettingsPage.qml:53
+#: dashboard/qml/SettingsPage.qml:62
 #, kde-format
 msgid "%1 %"
 msgstr "%1 %"
 
-#: dashboard/qml/SettingsPage.qml:59
+#: dashboard/qml/SettingsPage.qml:68
 #, kde-format
 msgid ""
 "A stronger foveation makes the image sharper in the center than in the "
@@ -372,143 +378,159 @@ msgid ""
 "The recommended values are between 20% and 50% for headsets without eye "
 "tracking and between 50% and 70% for headsets with eye tracking."
 msgstr ""
-"強めのフォビエーションの場合は、周辺部よりも中心部のほうが鮮明となり、"
-"デコーディングは早くなります。低遅延を必要とするゲームに有効"
-"となります。\n"
+"強めのフォビエーションの場合は、周辺部よりも中心部のほうが鮮明となり、デコー"
+"ディングは早くなります。低遅延を必要とするゲームに有効となります。\n"
 "\n"
 "弱めのフォビエーションの場合は、画面全体が同じ鮮明度となります。\n"
 "\n"
-"お勧めの設定は、アイトラッキングを対応したHMDの場合は20%~50%、"
-"アイトラッキングを対応しないHMDの場合は50%~70%です。"
+"お勧めの設定は、アイトラッキングを対応したHMDの場合は20%~50%、アイトラッキン"
+"グを対応しないHMDの場合は50%~70%です。"
 
-#: dashboard/qml/SettingsPage.qml:65
+#: dashboard/qml/SettingsPage.qml:74
 #, kde-format
 msgctxt "weaker foveation"
 msgid "Weaker"
 msgstr "弱"
 
-#: dashboard/qml/SettingsPage.qml:76
+#: dashboard/qml/SettingsPage.qml:85
 #, kde-format
 msgctxt "stronger foveation"
 msgid "Stronger"
 msgstr "強"
 
-#: dashboard/qml/SettingsPage.qml:86
+#: dashboard/qml/SettingsPage.qml:95
 #, kde-format
 msgid "Bitrate:"
 msgstr "ビットレート"
 
-#: dashboard/qml/SettingsPage.qml:90 dashboard/qml/SettingsPage.qml:92
+#: dashboard/qml/SettingsPage.qml:99 dashboard/qml/SettingsPage.qml:101
 #, kde-format
 msgctxt "bitrate"
 msgid "%1 Mbit/s"
 msgstr "%1 Mbps"
 
-#: dashboard/qml/SettingsPage.qml:102
+#: dashboard/qml/SettingsPage.qml:111
 #, kde-format
 msgid "Encoder layout:"
 msgstr "エンコーダー・レイアウト"
 
-#: dashboard/qml/SettingsPage.qml:105
+#: dashboard/qml/SettingsPage.qml:114
 #, kde-format
 msgctxt "encoder preset"
 msgid "Automatic"
 msgstr "自動"
 
-#: dashboard/qml/SettingsPage.qml:109
+#: dashboard/qml/SettingsPage.qml:118
 #, kde-format
 msgctxt "encoder preset"
 msgid "Manual"
 msgstr "マニュアル"
 
-#: dashboard/qml/SettingsPage.qml:113
+#: dashboard/qml/SettingsPage.qml:122
 #, kde-format
 msgctxt "encoder preset"
 msgid "Default preset"
 msgstr "デフォルト・プリセット"
 
-#: dashboard/qml/SettingsPage.qml:136
+#: dashboard/qml/SettingsPage.qml:145
 #, kde-format
 msgctxt "encoder preset"
 msgid "Low latency preset"
 msgstr "低遅延プリセット"
 
-#: dashboard/qml/SettingsPage.qml:161
+#: dashboard/qml/SettingsPage.qml:170
 #, kde-format
 msgctxt "encoder preset"
 msgid "Safe preset"
 msgstr "安定プリセット"
 
-#: dashboard/qml/SettingsPage.qml:184
+#: dashboard/qml/SettingsPage.qml:193
 #, kde-format
 msgid ""
 "To add a new encoder, split an existing encoder by clicking near an edge.\n"
 "Drag an edge to resize or remove encoders."
 msgstr ""
-"新しいエンコーダー追加するには、既存エンコーダの角をクリックして分割しましょう。\n"
+"新しいエンコーダー追加するには、既存エンコーダの角をクリックして分割しましょ"
+"う。\n"
 "角を引っ張って大きさの調整をできます。大きさゼロで削除となります。"
 
-#: dashboard/qml/SettingsPage.qml:211
+#: dashboard/qml/SettingsPage.qml:220
 #, kde-format
 msgid "Encoder:"
 msgstr "エンコーダー"
 
-#: dashboard/qml/SettingsPage.qml:220
+#: dashboard/qml/SettingsPage.qml:229
 #, kde-format
 msgctxt "automatic encoder setup"
 msgid "Auto"
 msgstr "自動"
 
-#: dashboard/qml/SettingsPage.qml:225
+#: dashboard/qml/SettingsPage.qml:234
 #, kde-format
 msgid "nvenc (NVIDIA GPUs)"
 msgstr "nvenc (NVIDIA GPU)"
 
-#: dashboard/qml/SettingsPage.qml:230
+#: dashboard/qml/SettingsPage.qml:239
 #, kde-format
 msgid "vaapi (AMD and Intel GPUs)"
 msgstr "vaapi (AMDやIntel GPU)"
 
-#: dashboard/qml/SettingsPage.qml:235
+#: dashboard/qml/SettingsPage.qml:244
 #, kde-format
 msgid "x264 (software encoding)"
 msgstr "x264 (ソフトエンコード)"
 
-#: dashboard/qml/SettingsPage.qml:240
+#: dashboard/qml/SettingsPage.qml:249
 #, kde-format
 msgid "Vulkan (Vulkan Video)"
 msgstr "Vulkan (Vulkan Video)"
 
-#: dashboard/qml/SettingsPage.qml:263
+#: dashboard/qml/SettingsPage.qml:272
 #, kde-format
 msgid "\"Auto\" will use hardware acceleration if it is available"
 msgstr "「自動」で当システムにとって最も安定した設定を使用します。"
 
-#: dashboard/qml/SettingsPage.qml:269
+#: dashboard/qml/SettingsPage.qml:278
 #, kde-format
 msgid "Codec:"
 msgstr "コーデック"
 
-#: dashboard/qml/SettingsPage.qml:276
+#: dashboard/qml/SettingsPage.qml:285
 #, kde-format
 msgctxt "automatic codec setup"
 msgid "Auto"
 msgstr "自動"
 
-#: dashboard/qml/SettingsPage.qml:280
+#: dashboard/qml/SettingsPage.qml:289
 #, kde-format
 msgid "H.264"
 msgstr "H.264"
 
-#: dashboard/qml/SettingsPage.qml:284
+#: dashboard/qml/SettingsPage.qml:293
 #, kde-format
 msgid "H.265"
 msgstr "H.265"
 
-#: dashboard/qml/SettingsPage.qml:288
+#: dashboard/qml/SettingsPage.qml:297
 #, kde-format
 msgid "AV1"
 msgstr "AV1"
+
+#: dashboard/qml/SettingsPage.qml:323
+#, kde-format
+msgid "Custom adb location"
+msgstr "特定なADBの場所"
+
+#: dashboard/qml/SettingsPage.qml:334
+#, kde-format
+msgid "Adb location:"
+msgstr "ADBの場所："
+
+#: dashboard/qml/SettingsPage.qml:343
+#, kde-format
+msgctxt "browse a file to choose the adb binary"
+msgid "Browse"
+msgstr "検索する"
 
 #: dashboard/qml/SteamLaunchOptions.qml:8
 #, kde-format
@@ -516,8 +538,8 @@ msgid ""
 "For Steam games, right click on the game in Steam, go in Properties > "
 "General and paste this in \"Launch options\":"
 msgstr ""
-"Steamゲームの場合は、ゲームに右クリックし、「プロパティ」・「一般」タブ・"
-"「起動オプション」に入力しましょう："
+"Steamゲームの場合は、ゲームに右クリックし、「プロパティ」・「一般」タブ・「起"
+"動オプション」に入力しましょう："
 
 #: dashboard/qml/SteamLaunchOptions.qml:20
 #, kde-format
@@ -573,11 +595,9 @@ msgid ""
 "</p><ul><li>The headset app version is in the \"About\" page</li><li>The "
 "server version is <b>%1</b></li></ul>"
 msgstr ""
-"<p>HMDアプリとサーバーのバージョンは一致していることが必要です。</p>"
-"<ul><li>HMDアプリのバージョンは「WiVRnについて」タブに確認できます。</li>"
-"<li>サーバーのバージョンは：<b>%1</b></li></ul>"
-
-
+"<p>HMDアプリとサーバーのバージョンは一致していることが必要です。</"
+"p><ul><li>HMDアプリのバージョンは「WiVRnについて」タブに確認できます。</"
+"li><li>サーバーのバージョンは：<b>%1</b></li></ul>"
 
 #: dashboard/qml/TroubleshootPage.qml:32
 #, kde-format
@@ -590,8 +610,8 @@ msgid ""
 "If you have reinstalled the server or the client or if you want to connect "
 "another headset, you must enable pairing before connecting."
 msgstr ""
-"サーバーかクライエント更インストールした場合、または"
-"別のHMDを接続したい場合、ペアリングを有効化しましょう。"
+"サーバーかクライエント更インストールした場合、または別のHMDを接続したい場合、"
+"ペアリングを有効化しましょう。"
 
 #: dashboard/qml/TroubleshootPage.qml:33
 #, kde-format
@@ -650,8 +670,8 @@ msgid ""
 "This wizard will help you set up WiVRn on your headset and connect it to "
 "your computer."
 msgstr ""
-"このセットアップウィザードは、HMDにWiVRnをインストールし、パソコンに接続できるように"
-"ご案内します。"
+"このセットアップウィザードは、HMDにWiVRnをインストールし、パソコンに接続でき"
+"るようにご案内します。"
 
 #: dashboard/qml/WizardPage.qml:83 dashboard/qml/WizardPage.qml:258
 #: dashboard/qml/WizardPage.qml:307 dashboard/qml/WizardPage.qml:438
@@ -691,8 +711,8 @@ msgid ""
 "For the Quest 2, 3, 3S, and Pro, you can get the app from the <a "
 "href=\"https://www.meta.com/experiences/7959676140827574/\">Meta store</a>."
 msgstr ""
-"Quest 2、3、3S、Proの場合、<a href=\"https://www.meta.com/experiences/7959676140827574/\">"
-"Metaストア</a>にて配信中です。"
+"Quest 2、3、3S、Proの場合、<a href=\"https://www.meta.com/"
+"experiences/7959676140827574/\">Metaストア</a>にて配信中です。"
 
 #: dashboard/qml/WizardPage.qml:164
 #, kde-format
@@ -700,8 +720,8 @@ msgid ""
 "A newer release is available: %1 → %2, the client app on the Meta store may "
 "not be compatible."
 msgstr ""
-"アップデートがあります：%1 → %2。現在バージョンにMetaストア版のHMDアプリは"
-"対応しない可能性があります。"
+"アップデートがあります：%1 → %2。現在バージョンにMetaストア版のHMDアプリは対"
+"応しない可能性があります。"
 
 #: dashboard/qml/WizardPage.qml:171
 #, kde-format
@@ -748,8 +768,7 @@ msgstr "起動したいアプリを選択しましょう"
 msgid ""
 "The application you choose will be started automatically when you connect "
 "your headset."
-msgstr ""
-"接続すると、選択したアプリが自動的に起動します。"
+msgstr "接続すると、選択したアプリが自動的に起動します。"
 
 #: dashboard/qml/WizardPage.qml:344
 #, kde-format
@@ -762,7 +781,8 @@ msgid ""
 "To connect over WiFi, start the WiVRn app on your headset, connect to \"%1\" "
 "and enter PIN \"%2\"."
 msgstr ""
-"WiFiで接続するには、HMDのWiVRnアプリを使い、「%1」に接続し、暗証番号に「%2」を入れましょう。"
+"WiFiで接続するには、HMDのWiVRnアプリを使い、「%1」に接続し、暗証番号に「%2」"
+"を入れましょう。"
 
 #: dashboard/qml/WizardPage.qml:356
 #, kde-format
@@ -794,8 +814,7 @@ msgstr "HMDに接続しました。"
 msgid ""
 "To connect another headset, make sure pairing is enabled in the dashboard "
 "before connecting."
-msgstr ""
-"他のHMDを接続するには、ペアリングが有効なのかどうか確認しましょう。"
+msgstr "他のHMDを接続するには、ペアリングが有効なのかどうか確認しましょう。"
 
 #: dashboard/qml/WizardPage.qml:443 dashboard/qml/WizardPage.qml:480
 #, kde-format

--- a/locale/ja/wivrn-dashboard.po
+++ b/locale/ja/wivrn-dashboard.po
@@ -140,24 +140,28 @@ msgstr "HMD"
 msgid "Last connection: %1 second ago"
 msgid_plural "Last connection: %1 seconds ago"
 msgstr[0] "前回の接続: %1 秒前"
+msgstr[1] "前回の接続: %1 秒前"
 
 #: dashboard/qml/HeadsetsPage.qml:31
 #, fuzzy, kde-format
 msgid "Last connection: %1 minute ago"
 msgid_plural "Last connection: %1 minutes ago"
 msgstr[0] "前回の接続: %1 分前"
+msgstr[1] "前回の接続: %1 分前"
 
 #: dashboard/qml/HeadsetsPage.qml:33
 #, fuzzy, kde-format
 msgid "Last connection: %1 hour ago"
 msgid_plural "Last connection: %1 hours ago"
 msgstr[0] "前回の接続: %1 時間前"
+msgstr[1] "前回の接続: %1 時間前"
 
 #: dashboard/qml/HeadsetsPage.qml:35
 #, fuzzy, kde-format
 msgid "Last connection: %1 day ago"
 msgid_plural "Last connection: %1 days ago"
 msgstr[0] "前回の接続: %1 日前"
+msgstr[1] "前回の接続: %1 日前"
 
 #: dashboard/qml/HeadsetsPage.qml:40
 #, kde-format

--- a/locale/ja/wivrn.po
+++ b/locale/ja/wivrn.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: WiVRn 0.16\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-10 07:14+0900\n"
+"POT-Creation-Date: 2025-04-20 17:32+0900\n"
 "PO-Revision-Date: 2024-06-20 10:33+0900\n"
 "Last-Translator: Mitsuami Megane <hello@mitsua.me>\n"
 "Language: Japanese\n"
@@ -37,15 +37,30 @@ msgstr "{}に接続できませんでした：({}) {}"
 msgid "Waiting for connection"
 msgstr "接続を待っています"
 
-#: client/scenes/lobby_gui.cpp:174 client/scenes/lobby_gui.cpp:367
-msgid "Cancel"
-msgstr "キャンセル"
+#: client/scenes/lobby_gui.cpp:131
+msgctxt "openxr_post_processing"
+msgid "Normal"
+msgstr "ノーマル"
 
-#: client/scenes/lobby_gui.cpp:180
+#: client/scenes/lobby_gui.cpp:134
+msgctxt "openxr_post_processing"
+msgid "Quality"
+msgstr "クオリティ"
+
+#: client/scenes/lobby_gui.cpp:136
+msgctxt "openxr_post_processing"
+msgid "Disabled"
+msgstr "無効"
+
+#: client/scenes/lobby_gui.cpp:197
+msgid "Disconnect"
+msgstr "切断する"
+
+#: client/scenes/lobby_gui.cpp:203
 msgid "Video stream interrupted"
 msgstr "動画ストリームは中断しました"
 
-#: client/scenes/lobby_gui.cpp:182
+#: client/scenes/lobby_gui.cpp:205
 msgid ""
 "Connection ready\n"
 "Start a VR application on your computer"
@@ -53,7 +68,7 @@ msgstr ""
 "接続に成功しました\n"
 "パソコンでVRアプリを起動して下さい"
 
-#: client/scenes/lobby_gui.cpp:184
+#: client/scenes/lobby_gui.cpp:207
 #, c++-format
 msgid ""
 "Connection ready\n"
@@ -62,48 +77,52 @@ msgstr ""
 "接続に成功しました\n"
 "{}でVRアプリを起動して下さい"
 
-#: client/scenes/lobby_gui.cpp:197
+#: client/scenes/lobby_gui.cpp:220
 msgid "Close"
 msgstr "やめる"
 
-#: client/scenes/lobby_gui.cpp:203
+#: client/scenes/lobby_gui.cpp:226
 msgid "Connection"
 msgstr "接続"
 
-#: client/scenes/lobby_gui.cpp:205
+#: client/scenes/lobby_gui.cpp:228
 #, c++-format
 msgid "Connection to {}"
 msgstr "{}に接続中"
 
-#: client/scenes/lobby_gui.cpp:235
+#: client/scenes/lobby_gui.cpp:258
 msgid "PIN"
 msgstr "暗証番号"
 
-#: client/scenes/lobby_gui.cpp:257
+#: client/scenes/lobby_gui.cpp:280
 msgid "Input the PIN displayed on the dashboard"
 msgstr "パソコンで表示された暗証番号を入力してください"
 
-#: client/scenes/lobby_gui.cpp:332
+#: client/scenes/lobby_gui.cpp:355
 msgid "Name"
 msgstr "表示名"
 
-#: client/scenes/lobby_gui.cpp:343
+#: client/scenes/lobby_gui.cpp:366
 msgid "Address"
 msgstr "アドレス"
 
-#: client/scenes/lobby_gui.cpp:352
+#: client/scenes/lobby_gui.cpp:375
 msgid "Port"
 msgstr "ポート番号"
 
-#: client/scenes/lobby_gui.cpp:360
+#: client/scenes/lobby_gui.cpp:383
 msgid "TCP only"
 msgstr "TCPのみを使用"
 
-#: client/scenes/lobby_gui.cpp:381
+#: client/scenes/lobby_gui.cpp:390
+msgid "Cancel"
+msgstr "やめる"
+
+#: client/scenes/lobby_gui.cpp:404
 msgid "Save"
 msgstr "保存する"
 
-#: client/scenes/lobby_gui.cpp:434
+#: client/scenes/lobby_gui.cpp:457
 msgid ""
 "Start a WiVRn server on your\n"
 "local network"
@@ -111,32 +130,32 @@ msgstr ""
 "ローカルネットワークでWiVRnサーバーを\n"
 "起動してみて下さい"
 
-#: client/scenes/lobby_gui.cpp:466
+#: client/scenes/lobby_gui.cpp:489
 msgid "Autoconnect"
 msgstr "自動接続"
 
-#: client/scenes/lobby_gui.cpp:492
+#: client/scenes/lobby_gui.cpp:515
 msgid "Connect"
 msgstr "接続する"
 
-#: client/scenes/lobby_gui.cpp:502
+#: client/scenes/lobby_gui.cpp:525
 msgid "Incompatible server version"
 msgstr "互換性のないサーバーです"
 
-#: client/scenes/lobby_gui.cpp:504
+#: client/scenes/lobby_gui.cpp:527
 msgid "Server not available"
 msgstr "サーバーは利用不可です"
 
-#: client/scenes/lobby_gui.cpp:590
+#: client/scenes/lobby_gui.cpp:613
 msgid "Refresh rate"
 msgstr "リフレッシュレート"
 
-#: client/scenes/lobby_gui.cpp:590 client/scenes/lobby_gui.cpp:592
+#: client/scenes/lobby_gui.cpp:613 client/scenes/lobby_gui.cpp:615
 msgctxt "automatic refresh rate"
 msgid "Automatic"
 msgstr "自動"
 
-#: client/scenes/lobby_gui.cpp:599
+#: client/scenes/lobby_gui.cpp:622
 msgid ""
 "Select refresh rate based on measured application performance.\n"
 "May cause flicker when a change happens."
@@ -144,145 +163,221 @@ msgstr ""
 "アプリケーションのパフォーマンスを基づいて自動的に設定します。\n"
 "変更時にチラツキが発生する可能性があります。"
 
-#: client/scenes/lobby_gui.cpp:616
+#: client/scenes/lobby_gui.cpp:639
 msgid "Minimum refresh rate"
 msgstr "最低リフレッシュレート"
 
-#: client/scenes/lobby_gui.cpp:638
+#: client/scenes/lobby_gui.cpp:662
 msgid "Resolution scale"
 msgstr "解像度"
 
-#: client/scenes/lobby_gui.cpp:638
+#: client/scenes/lobby_gui.cpp:666 client/scenes/lobby_gui.cpp:915
 #, c-format, c++-format
 msgid "%d%% - {}x{} per eye"
 msgstr "%d%% - 目あたり{}x{}"
 
-#: client/scenes/lobby_gui.cpp:648
+#: client/scenes/lobby_gui.cpp:677 client/scenes/lobby_gui.cpp:926
 #, c++-format
 msgid "Resolution larger than {}x{} may not be supported by the headset"
 msgstr ""
 "{}x{}以上の解像度は、お使いのヘッドセットではサポートされない場合があります。"
 
-#: client/scenes/lobby_gui.cpp:654
+#: client/scenes/lobby_gui.cpp:683
 msgid "Enable microphone"
 msgstr "マイクを有効する"
 
-#: client/scenes/lobby_gui.cpp:664
+#: client/scenes/lobby_gui.cpp:693
 msgid "Unprocessed Microphone Audio"
 msgstr "未処理のマイク音声"
 
-#: client/scenes/lobby_gui.cpp:670
+#: client/scenes/lobby_gui.cpp:699
 msgid "Force disable audio filters, such as noise cancellation"
 msgstr "ノイズ除去などのフィルターを無効化する"
 
-#: client/scenes/lobby_gui.cpp:677
+#: client/scenes/lobby_gui.cpp:706
 msgid "Enable hand tracking"
 msgstr "ハンドトラッキングを有効する"
 
-#: client/scenes/lobby_gui.cpp:684 client/scenes/lobby_gui.cpp:697
-#: client/scenes/lobby_gui.cpp:710 client/scenes/lobby_gui.cpp:722
+#: client/scenes/lobby_gui.cpp:713 client/scenes/lobby_gui.cpp:726
+#: client/scenes/lobby_gui.cpp:739 client/scenes/lobby_gui.cpp:751
 msgid "This feature is not supported by your headset"
 msgstr "デバイスはこの機能をサポートしていません"
 
-#: client/scenes/lobby_gui.cpp:690
+#: client/scenes/lobby_gui.cpp:719
 msgid "Enable eye tracking"
 msgstr "アイトラッキングを有効する"
 
-#: client/scenes/lobby_gui.cpp:703
+#: client/scenes/lobby_gui.cpp:732
 msgid "Enable face tracking"
 msgstr "顔トラッキングを有効する"
 
-#: client/scenes/lobby_gui.cpp:715
+#: client/scenes/lobby_gui.cpp:744
 msgid "Enable video passthrough in lobby"
 msgstr "ロビーでパススルーを有効する"
 
-#: client/scenes/lobby_gui.cpp:725
+#: client/scenes/lobby_gui.cpp:754
 msgid "Show performance metrics"
 msgstr "パフォーマンスグラフを表示する"
 
-#: client/scenes/lobby_gui.cpp:729
+#: client/scenes/lobby_gui.cpp:758
 msgid "Overlay can be toggled by pressing both thumbsticks"
 msgstr "両方のサムスティックを同時に押すことで切り替え可能"
 
-#: client/scenes/lobby_gui.cpp:759 client/scenes/lobby_gui.cpp:767
+#: client/scenes/lobby_gui.cpp:788 client/scenes/lobby_gui.cpp:796
 #: client/scenes/stream_stats.cpp:159
 msgid "CPU time"
 msgstr "CPU使用時間"
 
-#: client/scenes/lobby_gui.cpp:763
+#: client/scenes/lobby_gui.cpp:792
 msgid "CPU time [ms]"
 msgstr "CPU使用時間、ミリ秒"
 
-#: client/scenes/lobby_gui.cpp:773 client/scenes/lobby_gui.cpp:781
+#: client/scenes/lobby_gui.cpp:802 client/scenes/lobby_gui.cpp:810
 #: client/scenes/stream_stats.cpp:161
 msgid "GPU time"
 msgstr "GPU使用時間"
 
-#: client/scenes/lobby_gui.cpp:777
+#: client/scenes/lobby_gui.cpp:806
 msgid "GPU time [ms]"
 msgstr "GPU使用時間、ミリ秒"
 
-#: client/scenes/lobby_gui.cpp:867 client/scenes/lobby_gui.cpp:1506
+#: client/scenes/lobby_gui.cpp:825
+msgid "OpenXR post-processing"
+msgstr "OpenXRポストエフェクト"
+
+#: client/scenes/lobby_gui.cpp:829
+msgid "Supersampling"
+msgstr "スーパーサンプリング"
+
+#: client/scenes/lobby_gui.cpp:849
+msgid ""
+"Reduce flicker for high contrast edges.\n"
+"Useful when the input resolution is high compared to the headset display"
+msgstr ""
+"コントラストが高い部分のギザギザを低減する。\n"
+"ストリームの解像度は、HMDの解像度より高い場合は有用です。"
+
+#: client/scenes/lobby_gui.cpp:854
+msgid "Sharpening"
+msgstr "シャープ"
+
+#: client/scenes/lobby_gui.cpp:874
+msgid ""
+"Improve clarity of high contrast edges and counteract blur.\n"
+"Useful when the input resolution is low compared to the headset display"
+msgstr ""
+"ぼかしを低減し、コントラストが高い部分の鮮明度を向上する。\n"
+"ストリームの解像度は、HMDの解像度より低い場合に有用です。"
+
+#: client/scenes/lobby_gui.cpp:883
+msgid "Enable Snapdragon Game Super Resolution"
+msgstr "Snapdragon Game Super Resolutionを有効する"
+
+#: client/scenes/lobby_gui.cpp:891
+msgid ""
+"On this headset, this setting has been fully superseded by the native "
+"Sharpening setting above.\n"
+"Only enable if you know what you're doing."
+msgstr ""
+"この設定は、使用中のHMDでは非推奨です。"
+"OpenXRの方法を使用してください。"
+
+#: client/scenes/lobby_gui.cpp:893
+msgid ""
+"Client-side upscaling and sharpening, adds a performance cost on the headset"
+msgstr ""
+"HMD側のアップスケーリングやシャープニングを使用する場合、要求性能が上がります。"
+
+#: client/scenes/lobby_gui.cpp:911
+msgid "Upscaling factor"
+msgstr "アップスケーリング係数"
+
+#: client/scenes/lobby_gui.cpp:930
+msgid "Use edge direction"
+msgstr "エッジ方向を使用する"
+
+#: client/scenes/lobby_gui.cpp:936
+msgid "Adds an additional performance cost"
+msgstr "HMDに対する要求性能が上がります。"
+
+#: client/scenes/lobby_gui.cpp:941
+msgid "Edge threshold"
+msgstr "エッジのしきい値"
+
+#: client/scenes/lobby_gui.cpp:948 client/scenes/lobby_gui.cpp:957
+#, c++-format
+msgid "Recommended: {:.1f}"
+msgstr "推奨値：{:.1f}"
+
+#: client/scenes/lobby_gui.cpp:951
+msgid "Edge sharpness"
+msgstr "エッジのシャープ"
+
+#: client/scenes/lobby_gui.cpp:1045 client/scenes/lobby_gui.cpp:1691
 msgid "Licenses"
 msgstr "ライセンス"
 
-#: client/scenes/lobby_gui.cpp:1206
+#: client/scenes/lobby_gui.cpp:1384
 msgid "Microphone is enabled"
 msgstr "マイクは有効です"
 
-#: client/scenes/lobby_gui.cpp:1207
+#: client/scenes/lobby_gui.cpp:1385
 msgid "Microphone is disabled"
 msgstr "マイクは無効です"
 
-#: client/scenes/lobby_gui.cpp:1216
+#: client/scenes/lobby_gui.cpp:1394
 msgid "Hand tracking is enabled"
 msgstr "ハンドトラッキングは有効です"
 
-#: client/scenes/lobby_gui.cpp:1217
+#: client/scenes/lobby_gui.cpp:1395
 msgid "Hand tracking is disabled"
 msgstr "ハンドラッキングは無効です"
 
-#: client/scenes/lobby_gui.cpp:1226
+#: client/scenes/lobby_gui.cpp:1404
 msgid "Eye tracking is enabled"
 msgstr "アイトラッキングは有効です"
 
-#: client/scenes/lobby_gui.cpp:1227
+#: client/scenes/lobby_gui.cpp:1405
 msgid "Eye tracking is disabled"
 msgstr "アイトラッキングは無効です"
 
-#: client/scenes/lobby_gui.cpp:1237 client/scenes/lobby_gui.cpp:1248
+#: client/scenes/lobby_gui.cpp:1415 client/scenes/lobby_gui.cpp:1426
 msgid "Face tracking is enabled"
 msgstr "顔トラッキングは有効です"
 
-#: client/scenes/lobby_gui.cpp:1238 client/scenes/lobby_gui.cpp:1249
+#: client/scenes/lobby_gui.cpp:1416 client/scenes/lobby_gui.cpp:1427
 msgid "Face tracking is disabled"
 msgstr "フェーストラッキングは無効です"
 
-#: client/scenes/lobby_gui.cpp:1266
+#: client/scenes/lobby_gui.cpp:1444
 msgid "Add server"
 msgstr "サーバーを追加する"
 
-#: client/scenes/lobby_gui.cpp:1491
+#: client/scenes/lobby_gui.cpp:1673
 msgid "Server list"
 msgstr "サーバー"
 
-#: client/scenes/lobby_gui.cpp:1494
+#: client/scenes/lobby_gui.cpp:1676
 msgid "Settings"
 msgstr "設定"
 
-#: client/scenes/lobby_gui.cpp:1498
+#: client/scenes/lobby_gui.cpp:1679
+msgid "Post-processing"
+msgstr "ポストエフェクト"
+
+#: client/scenes/lobby_gui.cpp:1683
 msgid "Debug"
 msgstr "デバッグ"
 
-#: client/scenes/lobby_gui.cpp:1503
+#: client/scenes/lobby_gui.cpp:1688
 msgid "About"
 msgstr "WiVRnについて"
 
-#: client/scenes/lobby_gui.cpp:1509
+#: client/scenes/lobby_gui.cpp:1694
 msgid "Exit"
 msgstr "完了"
 
-#: client/scenes/lobby_gui.cpp:1523
+#: client/scenes/lobby_gui.cpp:1708
 msgid ""
 "Press A or X or put your palm up\n"
 "to move the main window"
@@ -290,7 +385,7 @@ msgstr ""
 "ウィンドウを移動するには、手のひらを上に向けるか、\n"
 "ＡまたはＢボタンを押しましょう"
 
-#: client/scenes/lobby_gui.cpp:1525
+#: client/scenes/lobby_gui.cpp:1710
 msgid "Press A or X to move the main window"
 msgstr "ＡまたはＸボタンを押してウィンドウを移動"
 


### PR DESCRIPTION
The GitHub action seems to have some false positive complaints.

I set `"Plural-Forms: nplurals=1; plural=0;\n"` to indicate only 1 form.

And it complains about the elements that only have 1 msgstr element:

```
#: dashboard/qml/HeadsetsPage.qml:29
#, fuzzy, kde-format
msgid "Last connection: %1 second ago"
msgid_plural "Last connection: %1 seconds ago"
msgstr[0] "前回の接続: %1 秒前"
```

```
Warning: 🇯🇵 Translation for 'Last connection: %1 second ago' is missing
```

Edit: I just went and added duplicate entries for the plurals instead.