### PR TITLE
fix client build dependencies

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -60,7 +60,7 @@ See [Server](#server-pc) for the server compile options.
 # Client (headset)
 
 #### Build dependencies
-As Arch package names: git pkgconf glslang cmake jdk17-temurin librsvg cli11 ktx_software-git ([AUR](https://aur.archlinux.org/packages/ktx_software-git))
+As Arch package names: git pkgconf glslang cmake jdk17-temurin([AUR](https://aur.archlinux.org/packages/jdk17-temurin)) librsvg cli11 ktx_software-git ([AUR](https://aur.archlinux.org/packages/ktx_software-git)) python3
 
 OpenSSL build dependencies are also needed, as described [here](https://github.com/openssl/openssl/blob/master/INSTALL.md#prerequisites), in particular perl 5.
 


### PR DESCRIPTION
Got the following error inside my arch distrobox:
```
[166/318] Generating glyph_set.cpp
  FAILED: client/glyph_set.cpp /home/etch/Documents/WiVRn/.cxx/RelWithDebInfo/461k4m51/arm64-v8a/client/glyph_set.cpp 
  cd /home/etch/Documents/WiVRn/.cxx/RelWithDebInfo/461k4m51/arm64-v8a/client && python3 /home/etch/Documents/WiVRn/cmake/../tools/extract_charset.py /home/etch/Documents/WiVRn/client/../locale/es/wivrn.po /home/etch/Documents/WiVRn/client/../locale/fr/wivrn.po /home/etch/Documents/WiVRn/client/../locale/it/wivrn.po /home/etch/Documents/WiVRn/client/../locale/ja/wivrn.po /home/etch/Documents/WiVRn/client/../locale/pt_BR/wivrn.po /home/etch/Documents/WiVRn/client/../locale/zh_TW/wivrn.po > /home/etch/Documents/WiVRn/.cxx/RelWithDebInfo/461k4m51/arm64-v8a/client/glyph_set.cpp
  ```
  
I also couldn't find a `jdk17-temurin` arch package