### PR TITLE
Make patch commits reproducible

### DIFF
--- a/patches/apply.sh
+++ b/patches/apply.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 if [ -d ".git" ] ; then
-	git config user.email > /dev/null || git config user.email "git-am@invalid"
-	git config user.name > /dev/null || git config user.name "no name"
-	git config --local commit.gpgsign false
+	git config --worktree user.email "git-am@invalid"
+	git config --worktree user.name "no name"
+	git config --worktree commit.gpgsign false
 	git am --abort 2> /dev/null
 	git checkout .
 	exec git am --committer-date-is-author-date "$@"

--- a/patches/apply.sh
+++ b/patches/apply.sh
@@ -6,7 +6,7 @@ if [ -d ".git" ] ; then
 	git config --local commit.gpgsign false
 	git am --abort 2> /dev/null
 	git checkout .
-	exec git am "$@"
+	exec git am --committer-date-is-author-date "$@"
 fi
 
 # There is no reliable way to apply a patch and succeed if it was


### PR DESCRIPTION
The timestamp reproducibility will be useful for building wivrn for multiple architectures in separate build trees.

Committer reproducibility could be useful for ensuring compatibility between wivrn builds across multiple *machines* with different default commit authors, but is probably not desirable if the script is ever used outside of the cmake build.