### PR TITLE
wivrnctl toggle-performance-graph

### DIFF
--- a/client/scenes/stream.h
+++ b/client/scenes/stream.h
@@ -127,7 +127,7 @@ private:
 	std::optional<audio> audio_handle;
 
 	std::optional<imgui_context> imgui_ctx;
-	bool plots_visible = true;
+	std::atomic<bool> plots_visible = false;
 	XrAction plots_toggle_1 = XR_NULL_HANDLE;
 	XrAction plots_toggle_2 = XR_NULL_HANDLE;
 
@@ -157,6 +157,7 @@ public:
 	void operator()(to_headset::audio_stream_description &&);
 	void operator()(to_headset::video_stream_description &&);
 	void operator()(to_headset::refresh_rate_change &&);
+	void operator()(to_headset::toggle_performance_graph &&);
 	void operator()(audio_data &&);
 
 	void push_blit_handle(wivrn::shard_accumulator * decoder, std::shared_ptr<wivrn::shard_accumulator::blit_handle> handle);
@@ -245,6 +246,7 @@ private:
 	XrTime last_metric_time = 0;
 	int metrics_offset = 0;
 
+	void setup_imgui();
 	void accumulate_metrics(XrTime predicted_display_time, const std::vector<std::shared_ptr<wivrn::shard_accumulator::blit_handle>> & blit_handles, const gpu_timestamps & timestamps);
 	std::vector<XrCompositionLayerQuad> plot_performance_metrics(XrTime predicted_display_time);
 };

--- a/client/scenes/stream_network.cpp
+++ b/client/scenes/stream_network.cpp
@@ -74,6 +74,11 @@ void scenes::stream::operator()(to_headset::refresh_rate_change && rate)
 	session.set_refresh_rate(rate.fps);
 }
 
+void scenes::stream::operator()(to_headset::toggle_performance_graph &&)
+{
+	plots_visible = !plots_visible;
+}
+
 void scenes::stream::operator()(to_headset::timesync_query && query)
 {
 	network_session->send_stream(from_headset::timesync_response{

--- a/common/wivrn_packets.h
+++ b/common/wivrn_packets.h
@@ -611,6 +611,9 @@ struct refresh_rate_change
 	float fps;
 };
 
+struct toggle_performance_graph
+{};
+
 using packets = std::variant<
         crypto_handshake,
         pin_check_2,
@@ -623,6 +626,7 @@ using packets = std::variant<
         haptics,
         timesync_query,
         tracking_control,
-        refresh_rate_change>;
+        refresh_rate_change,
+        toggle_performance_graph>;
 } // namespace to_headset
 } // namespace wivrn

--- a/dbus/io.github.wivrn.Server.xml
+++ b/dbus/io.github.wivrn.Server.xml
@@ -40,6 +40,7 @@
 			<arg type="s" name="Pin" direction="out"/>
 		</method>
 		<method name="DisablePairing"/>
+		<method name="TogglePerformanceGraph"/>
 
 		<property name="HeadsetConnected"      type="b" access="read"/>
 		<property name="SteamCommand"          type="s" access="read"/>

--- a/server/accept_connection.cpp
+++ b/server/accept_connection.cpp
@@ -35,6 +35,11 @@ static void handle_event_from_main_loop(to_monado::set_bitrate)
 	// Ignore bitrate request when no headset is connected
 }
 
+static void handle_event_from_main_loop(to_monado::toggle_performance_graph)
+{
+	// Ignore request when no headset is connected
+}
+
 std::unique_ptr<wivrn::TCP> wivrn::accept_connection(int watch_fd, std::function<bool()> quit)
 {
 	wivrn_ipc_socket_monado->send(from_monado::headset_disconnected{});

--- a/server/driver/wivrn_connection.cpp
+++ b/server/driver/wivrn_connection.cpp
@@ -43,6 +43,11 @@ static void handle_event_from_main_loop(to_monado::set_bitrate)
 	// Ignore bitrate request when no headset is connected
 }
 
+static void handle_event_from_main_loop(to_monado::toggle_performance_graph)
+{
+	// Ignore this request when no headset is connected
+}
+
 static std::string clean_key(std::string key)
 {
 	static const std::regex header{"^-+BEGIN .*-+$", std::regex_constants::multiline};

--- a/server/driver/wivrn_session.cpp
+++ b/server/driver/wivrn_session.cpp
@@ -588,6 +588,11 @@ void wivrn_session::operator()(to_monado::set_bitrate && data)
 	comp_target->set_bitrate(data.bitrate_bps);
 }
 
+void wivrn_session::operator()(to_monado::toggle_performance_graph &&)
+{
+	send_control(to_headset::toggle_performance_graph{});
+}
+
 struct refresh_rate_adjuster
 {
 	std::chrono::seconds period{10};

--- a/server/driver/wivrn_session.h
+++ b/server/driver/wivrn_session.h
@@ -180,6 +180,7 @@ public:
 
 	void operator()(to_monado::disconnect &&);
 	void operator()(to_monado::set_bitrate &&);
+	void operator()(to_monado::toggle_performance_graph &&);
 
 	template <typename T>
 	void send_stream(T && packet)

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -711,6 +711,16 @@ gboolean on_handle_disable_pairing(WivrnServer * skeleton, GDBusMethodInvocation
 	return G_SOURCE_CONTINUE;
 }
 
+gboolean on_handle_toggle_performance_graph(WivrnServer * skeleton,
+                                            GDBusMethodInvocation * invocation,
+                                            gpointer user_data)
+{
+	wivrn_ipc_socket_main_loop->send(to_monado::toggle_performance_graph{});
+
+	g_dbus_method_invocation_return_value(invocation, nullptr);
+	return G_SOURCE_CONTINUE;
+}
+
 void on_bitrate(WivrnServer * server, const GParamSpec * pspec, gpointer data)
 {
 	auto bitrate = wivrn_server_get_bitrate(server);
@@ -818,6 +828,11 @@ void on_name_acquired(GDBusConnection * connection, const gchar * name, gpointer
 	g_signal_connect(dbus_server,
 	                 "handle-quit",
 	                 G_CALLBACK(on_handle_quit),
+	                 NULL);
+
+	g_signal_connect(dbus_server,
+	                 "handle-toggle-performance-graph",
+	                 G_CALLBACK(on_handle_toggle_performance_graph),
 	                 NULL);
 
 	g_signal_connect(dbus_server,

--- a/server/wivrn_ipc.h
+++ b/server/wivrn_ipc.h
@@ -60,7 +60,10 @@ struct set_bitrate
 	uint32_t bitrate_bps;
 };
 
-using packets = std::variant<disconnect, set_bitrate>;
+struct toggle_performance_graph
+{};
+
+using packets = std::variant<disconnect, set_bitrate, toggle_performance_graph>;
 } // namespace to_monado
 
 extern std::optional<wivrn::typed_socket<wivrn::UnixDatagram, to_monado::packets, from_monado::packets>> wivrn_ipc_socket_monado;

--- a/tools/wivrnctl/main.cpp
+++ b/tools/wivrnctl/main.cpp
@@ -286,6 +286,11 @@ void disconnect()
 	call_method(get_user_bus(), "Disconnect", "");
 }
 
+void toggle_performance_graph()
+{
+	call_method(get_user_bus(), "TogglePerformanceGraph", "");
+}
+
 void set_bitrate(std::string bitrate_str)
 {
 	auto suffix = bitrate_str.back();
@@ -373,6 +378,9 @@ int main(int argc, char ** argv)
 
 	app.add_subcommand("disconnect", "Disconnect headset")
 	        ->callback(disconnect);
+
+	app.add_subcommand("toggle-performance-graph", "Toggle the performance graph on the headset")
+	        ->callback(toggle_performance_graph);
 
 	std::string bitrate_str;
 	auto bitrate_command = app.add_subcommand("set-bitrate", "Set encoding bitrate");


### PR DESCRIPTION
Adds a `wivrnctl toggle-performance-graph` sub-command. This allows toggling the plots for people who don't use standalone controllers, or people who prefer to use a shortcut from their computer (thumbstick actuation lifespans are scary).

Behavior summary:
- the imgui context and swapchain are created when needed
- client hotkey combo is only used if "Show Performance Metrics" was enabled before connecting
- the client settings stay untouched (on next connect, plots will show depending on "Show Performance Metrics")
