### PR TITLE
fixed foveation: account for asymmetric v-fov

### DIFF
--- a/server/driver/wivrn_foveation.cpp
+++ b/server/driver/wivrn_foveation.cpp
@@ -233,9 +233,7 @@ void wivrn_foveation::compute_params(
 
 			auto angle_x = convergence_angle(views[i].pose.position.x, e.x);
 			tan_center[i].x = angles_to_center(view.x + angle_x, views[i].fov.angleLeft, views[i].fov.angleRight);
-
-			auto offset_y = (views[i].fov.angleDown + views[i].fov.angleUp) / 2;
-			tan_center[i].y = angles_to_center(-view.y - e.y, views[i].fov.angleUp, views[i].fov.angleDown) + offset_y;
+			tan_center[i].y = angles_to_center(-view.y - e.y, views[i].fov.angleUp, views[i].fov.angleDown);
 		}
 	}
 
@@ -247,7 +245,10 @@ void wivrn_foveation::compute_params(
 		else
 			params[i].x = {uint16_t(src[i].extent.w)};
 		if (foveated_height < src[i].extent.h)
-			fill_param_2d(tan_center[i].y, foveated_height, src[i].extent.h, params[i].y);
+		{
+			auto offset_y = (views[i].fov.angleDown + views[i].fov.angleUp) / 2;
+			fill_param_2d(tan_center[i].y + offset_y, foveated_height, src[i].extent.h, params[i].y);
+		}
 		else
 			params[i].y = {uint16_t(src[i].extent.h)};
 	}


### PR DESCRIPTION
on some later headsets, the lcd panels are angled and fov.angleUp has a higher range than fov.angleDown.

with fixed foveation, this puts the sweet spot at the center of the screen, which is above the gaze when looking forward on the horizontal plane.

this change applies the same offset to fixed foveation as what we've been using for dynamic, bringing the sweet spot to the horizontal.