### PR TITLE
Use shorter serial for generic trackers

### DIFF
--- a/server/driver/wivrn_generic_tracker.cpp
+++ b/server/driver/wivrn_generic_tracker.cpp
@@ -126,7 +126,8 @@ wivrn_generic_tracker::wivrn_generic_tracker(int index, xrt_device * hmd, wivrn_
 {
 	auto unique_name = std::format("WiVRn Generic Tracker #{}", index + 1);
 	strlcpy(str, unique_name.c_str(), std::size(str));
-	strlcpy(serial, unique_name.c_str(), std::size(serial));
+	auto unique_serial = std::format("wivrn-{}", index + 1);
+	strlcpy(serial, unique_serial.c_str(), std::size(serial));
 
 	pose_input.name = XRT_INPUT_GENERIC_TRACKER_POSE;
 	pose_input.active = true;


### PR DESCRIPTION
Today, I tried the new feature to forward the tracking data provided by Quest headsets for elbows, chest, and optionally lower body.
The data seemed to be forwarded correctly. However, when I tried mapping them in Resonite, I discovered that only one of these trackers was properly processed by the game, and it had the truncated name "WiVRn Generic Tr".
My educated guess was that Resonite, for one reason or another, could not process tracker serial numbers longer than 16 characters, so all three WiVRn trackers were shadowing each other due to their long name.

These changes give shorter serial numbers to the trackers (in the format "wivrn-1", "wivrn-2", etc) while still keeping their display name as they are today ("WiVRn Generic Tracker #1" etc) for metadata purposes.
And indeed, this fixes my problem in Resonite, and all three trackers are listed with their serial number intact and can be mapped correctly.