### PR TITLE
vaapi: 10-bit hevc/av1 encoding

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,7 +22,7 @@ Scaling is applied in a foveated fashion: the center has a 1:1 ratio and the res
 	"scale": 0.5
 }
 ```
-The x and y resolution of the streamed video are half the size on the headsed, reduces the required bandwidth and encoding/decoding time by about 4.
+The x and y resolution of the streamed video are half the size on the headset, reduces the required bandwidth and encoding/decoding time by about 4.
 
 ```json
 {
@@ -35,6 +35,11 @@ Scales x by a 0.75 factor, and y by a 0.5 factor.
 Default value: `50000000` (50Mb/s)
 
 Bitrate of the video, in bit/s. Split among decoders based on size and codecs.
+
+## `bit-depth`
+Default value: `8` (bits)
+
+Bit depth of the video. 8-bit is supported by all encoders. 10-bit is supported by `vaapi` encoders using `h265` or `av1`.
 
 ## `encoders`
 A list of encoders to use.

--- a/server/driver/configuration.cpp
+++ b/server/driver/configuration.cpp
@@ -135,6 +135,7 @@ configuration::encoder parse_encoder(const nlohmann::json & item)
 	SET_IF(codec);
 	if (e.codec == wivrn::video_codec(-1))
 		throw std::runtime_error("invalid codec value " + item["codec"].get<std::string>());
+	SET_IF(use_10bit);
 	SET_IF(options);
 	SET_IF(device);
 	return e;

--- a/server/driver/configuration.cpp
+++ b/server/driver/configuration.cpp
@@ -135,7 +135,6 @@ configuration::encoder parse_encoder(const nlohmann::json & item)
 	SET_IF(codec);
 	if (e.codec == wivrn::video_codec(-1))
 		throw std::runtime_error("invalid codec value " + item["codec"].get<std::string>());
-	SET_IF(use_10bit);
 	SET_IF(options);
 	SET_IF(device);
 	return e;
@@ -188,6 +187,9 @@ configuration::configuration()
 
 		if (auto it = json.find("use-steamvr-lh"); it != json.end())
 			use_steamvr_lh = *it;
+
+		if (auto it = json.find("encode_10bit"); it != json.end())
+			encode_10bit = *it;
 
 		if (auto it = json.find("tcp-only"); it != json.end())
 			tcp_only = *it;

--- a/server/driver/configuration.cpp
+++ b/server/driver/configuration.cpp
@@ -188,8 +188,8 @@ configuration::configuration()
 		if (auto it = json.find("use-steamvr-lh"); it != json.end())
 			use_steamvr_lh = *it;
 
-		if (auto it = json.find("encode_10bit"); it != json.end())
-			encode_10bit = *it;
+		if (auto it = json.find("bit-depth"); it != json.end())
+			bit_depth = *it;
 
 		if (auto it = json.find("tcp-only"); it != json.end())
 			tcp_only = *it;

--- a/server/driver/configuration.h
+++ b/server/driver/configuration.h
@@ -57,12 +57,12 @@ struct configuration
 	std::vector<encoder> encoders;
 	std::optional<encoder> encoder_passthrough;
 	std::optional<int> bitrate;
+	int bit_depth = 8;
 	std::optional<std::array<double, 2>> scale;
 	std::optional<std::array<float, 3>> grip_surface;
 	std::vector<std::string> application;
 	bool debug_gui = false;
 	bool use_steamvr_lh = false;
-	bool encode_10bit = false;
 	bool tcp_only = false;
 	service_publication publication = service_publication::avahi;
 

--- a/server/driver/configuration.h
+++ b/server/driver/configuration.h
@@ -50,6 +50,7 @@ struct configuration
 		std::optional<double> offset_y;
 		std::optional<int> group;
 		std::optional<wivrn::video_codec> codec;
+		std::optional<bool> use_10bit;
 		std::map<std::string, std::string> options;
 		std::optional<std::string> device;
 	};

--- a/server/driver/configuration.h
+++ b/server/driver/configuration.h
@@ -50,7 +50,6 @@ struct configuration
 		std::optional<double> offset_y;
 		std::optional<int> group;
 		std::optional<wivrn::video_codec> codec;
-		std::optional<bool> use_10bit;
 		std::map<std::string, std::string> options;
 		std::optional<std::string> device;
 	};
@@ -63,6 +62,7 @@ struct configuration
 	std::vector<std::string> application;
 	bool debug_gui = false;
 	bool use_steamvr_lh = false;
+	bool encode_10bit = false;
 	bool tcp_only = false;
 	service_publication publication = service_publication::avahi;
 

--- a/server/driver/wivrn_comp_target.cpp
+++ b/server/driver/wivrn_comp_target.cpp
@@ -409,7 +409,8 @@ static void comp_wivrn_create_images(struct comp_target * ct, const struct comp_
 
 	target_init_semaphores(cn);
 
-	if (cn->settings[0].use_10bit)
+	// will fail on encoder init if bit_depth is arbitrary garbage
+	if (cn->settings[0].bit_depth == 10)
 		ct->format = VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16;
 	else
 		ct->format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;

--- a/server/encoder/encoder_settings.h
+++ b/server/encoder/encoder_settings.h
@@ -39,7 +39,7 @@ struct encoder_settings : public to_headset::video_stream_description::item
 	std::map<std::string, std::string> options; // additional encoder-specific configuration
 	// encoders in the same group are executed in sequence
 	int group = 0;
-	bool use_10bit;
+	int bit_depth;
 	std::optional<std::string> device;
 };
 

--- a/server/encoder/encoder_settings.h
+++ b/server/encoder/encoder_settings.h
@@ -39,6 +39,7 @@ struct encoder_settings : public to_headset::video_stream_description::item
 	std::map<std::string, std::string> options; // additional encoder-specific configuration
 	// encoders in the same group are executed in sequence
 	int group = 0;
+	bool use_10bit;
 	std::optional<std::string> device;
 };
 

--- a/server/encoder/video_encoder_nvenc.cpp
+++ b/server/encoder/video_encoder_nvenc.cpp
@@ -144,8 +144,8 @@ video_encoder_nvenc::video_encoder_nvenc(
         fps(fps),
         bitrate(settings.bitrate)
 {
-	if (settings.use_10bit)
-		throw std::runtime_error("nvenc encoder does not support 10-bit encoding");
+	if (settings.bit_depth != 8)
+		throw std::runtime_error("nvenc encoder only supports 8-bit encoding");
 
 	std::tie(cuda_fn, nvenc_fn, fn, cuda, session_handle) = init();
 	assert(settings.width % 32 == 0);

--- a/server/encoder/video_encoder_nvenc.cpp
+++ b/server/encoder/video_encoder_nvenc.cpp
@@ -144,6 +144,9 @@ video_encoder_nvenc::video_encoder_nvenc(
         fps(fps),
         bitrate(settings.bitrate)
 {
+	if (settings.use_10bit)
+		throw std::runtime_error("nvenc encoder does not support 10-bit encoding");
+
 	std::tie(cuda_fn, nvenc_fn, fn, cuda, session_handle) = init();
 	assert(settings.width % 32 == 0);
 	assert(settings.height % 32 == 0);

--- a/server/encoder/video_encoder_vulkan_h264.cpp
+++ b/server/encoder/video_encoder_vulkan_h264.cpp
@@ -192,6 +192,9 @@ std::unique_ptr<wivrn::video_encoder_vulkan_h264> wivrn::video_encoder_vulkan_h2
 	                vk::VideoEncodeCapabilitiesKHR,
 	                vk::VideoEncodeH264CapabilitiesKHR>(video_profile_info.get());
 
+	if (settings.use_10bit)
+		throw std::runtime_error("h264 codec does not support 10-bit encoding");
+
 	std::unique_ptr<video_encoder_vulkan_h264> self(new video_encoder_vulkan_h264(vk, rect, video_caps, encode_caps, fps, stream_idx, settings));
 
 	vk::VideoEncodeH264SessionParametersAddInfoKHR h264_add_info{};

--- a/server/encoder/video_encoder_vulkan_h264.cpp
+++ b/server/encoder/video_encoder_vulkan_h264.cpp
@@ -192,8 +192,8 @@ std::unique_ptr<wivrn::video_encoder_vulkan_h264> wivrn::video_encoder_vulkan_h2
 	                vk::VideoEncodeCapabilitiesKHR,
 	                vk::VideoEncodeH264CapabilitiesKHR>(video_profile_info.get());
 
-	if (settings.use_10bit)
-		throw std::runtime_error("h264 codec does not support 10-bit encoding");
+	if (settings.bit_depth != 8)
+		throw std::runtime_error("h264 codec only supports 8-bit encoding");
 
 	std::unique_ptr<video_encoder_vulkan_h264> self(new video_encoder_vulkan_h264(vk, rect, video_caps, encode_caps, fps, stream_idx, settings));
 

--- a/server/encoder/video_encoder_x264.cpp
+++ b/server/encoder/video_encoder_x264.cpp
@@ -93,6 +93,9 @@ video_encoder_x264::video_encoder_x264(
         uint8_t stream_idx) :
         video_encoder(stream_idx, settings.channels, settings.bitrate_multiplier, false)
 {
+	if (settings.use_10bit)
+		throw std::runtime_error("x264 encoder does not support 10-bit encoding");
+
 	if (settings.codec != h264)
 	{
 		U_LOG_W("requested x264 encoder with codec != h264");

--- a/server/encoder/video_encoder_x264.cpp
+++ b/server/encoder/video_encoder_x264.cpp
@@ -93,8 +93,8 @@ video_encoder_x264::video_encoder_x264(
         uint8_t stream_idx) :
         video_encoder(stream_idx, settings.channels, settings.bitrate_multiplier, false)
 {
-	if (settings.use_10bit)
-		throw std::runtime_error("x264 encoder does not support 10-bit encoding");
+	if (settings.bit_depth != 8)
+		throw std::runtime_error("x264 encoder only supports 8-bit encoding");
 
 	if (settings.codec != h264)
 	{


### PR DESCRIPTION
10-bit encoding is now supported for H265 and AV1 on VAAPI only. Tested H265+AV1 on AMD.

Added a new boolean `use_10bit` to encoder config. This must be the same for all encoders. The pass-through encoder inherits the encoder+codec+10bit settings from the first encoder if its 10-bit setting is different from the color encoders.

I ended up not separating the alpha channel for now. I'm not sure if the performance benefits would make it worth the extra maintenance burden. For example, I can't think of use cases where pass-through would be on, but the decoding latency of a 6Mib/s stream would matter.

---

I'm not looking into the dashboard changes just yet, mostly because we'll also want to think about how to make this feel intuitive. I think the 10-bit option should be a global switch that affects all encoders

I would probably ship a 10-bit preset at the very least, but there are other challenges we'll need to consider for the UI, such as:
- making sure people don't mix 10-bit with non-10-bit encoders
- making sure people don't select codect/encoders that do not support 10-bit