### PR TITLE
Move face/body tracker creation logic into constructors

### DIFF
--- a/client/scenes/lobby.h
+++ b/client/scenes/lobby.h
@@ -30,6 +30,7 @@
 #include "wifi_lock.h"
 #include "wivrn_config.h"
 #include "wivrn_discover.h"
+#include "wivrn_packets.h"
 #include <vulkan/vulkan_raii.hpp>
 
 #include "xr/system.h"

--- a/client/xr/fb_face_tracker2.cpp
+++ b/client/xr/fb_face_tracker2.cpp
@@ -19,6 +19,7 @@
 #include "fb_face_tracker2.h"
 #include "wivrn_packets.h"
 #include "xr/instance.h"
+#include "xr/session.h"
 #include <cstdint>
 #include <openxr/openxr.h>
 
@@ -29,11 +30,25 @@ XrResult xr::destroy_fb_face_tracker2(XrFaceTracker2FB id)
 	return xrDestroyFaceTracker2FB(id);
 }
 
-xr::fb_face_tracker2::fb_face_tracker2(instance & inst, XrFaceTracker2FB h)
+xr::fb_face_tracker2::fb_face_tracker2(instance & inst, session & s)
 {
-	id = h;
+	auto xrCreateFaceTracker2FB = inst.get_proc<PFN_xrCreateFaceTracker2FB>("xrCreateFaceTracker2FB");
 	xrGetFaceExpressionWeights2FB = inst.get_proc<PFN_xrGetFaceExpressionWeights2FB>("xrGetFaceExpressionWeights2FB");
 	xrDestroyFaceTracker2FB = inst.get_proc<PFN_xrDestroyFaceTracker2FB>("xrDestroyFaceTracker2FB");
+	assert(xrCreateFaceTracker2FB);
+
+	XrFaceTrackingDataSource2FB data_sources[1];
+	data_sources[0] = XR_FACE_TRACKING_DATA_SOURCE2_VISUAL_FB;
+
+	XrFaceTrackerCreateInfo2FB create_info{
+	        .type = XR_TYPE_FACE_TRACKER_CREATE_INFO2_FB,
+	        .next = nullptr,
+	        .faceExpressionSet = XR_FACE_EXPRESSION_SET2_DEFAULT_FB,
+	        .requestedDataSourceCount = 1,
+	        .requestedDataSources = data_sources,
+	};
+
+	CHECK_XR(xrCreateFaceTracker2FB(s, &create_info, &id));
 }
 
 void xr::fb_face_tracker2::get_weights(XrTime time, wivrn::from_headset::tracking::fb_face2 & out_expressions)

--- a/client/xr/fb_face_tracker2.h
+++ b/client/xr/fb_face_tracker2.h
@@ -25,6 +25,7 @@
 namespace xr
 {
 class instance;
+class session;
 
 XrResult destroy_fb_face_tracker2(XrFaceTracker2FB);
 
@@ -36,7 +37,7 @@ class fb_face_tracker2 : public utils::handle<XrFaceTracker2FB, destroy_fb_face_
 public:
 	using packet_type = wivrn::from_headset::tracking::fb_face2;
 	fb_face_tracker2() = default;
-	fb_face_tracker2(instance & inst, XrFaceTracker2FB h);
+	fb_face_tracker2(instance & inst, session & s);
 
 	void get_weights(XrTime time, packet_type & out_expressions);
 };

--- a/client/xr/pico_body_tracker.cpp
+++ b/client/xr/pico_body_tracker.cpp
@@ -30,10 +30,19 @@ XrResult xr::destroy_pico_body_tracker(XrBodyTrackerBD id)
 	return xrDestroyBodyTrackerBD(id);
 }
 
-xr::pico_body_tracker::pico_body_tracker(instance & inst, XrBodyTrackerBD h)
+xr::pico_body_tracker::pico_body_tracker(instance & inst, session & s)
 {
-	id = h;
+	auto xrCreateBodyTrackerBD = inst.get_proc<PFN_xrCreateBodyTrackerBD>("xrCreateBodyTrackerBD");
 	xrLocateBodyJointsBD = inst.get_proc<PFN_xrLocateBodyJointsBD>("xrLocateBodyJointsBD");
+	assert(xrCreateBodyTrackerBD);
+
+	XrBodyTrackerCreateInfoBD create_info{
+	        .type = XR_TYPE_BODY_TRACKER_CREATE_INFO_BD,
+	        .next = nullptr,
+	        .jointSet = XR_BODY_JOINT_SET_FULL_BODY_JOINTS_BD,
+	};
+
+	CHECK_XR(xrCreateBodyTrackerBD(s, &create_info, &id));
 }
 
 size_t xr::pico_body_tracker::count() const

--- a/client/xr/pico_body_tracker.h
+++ b/client/xr/pico_body_tracker.h
@@ -28,6 +28,7 @@
 namespace xr
 {
 class instance;
+class session;
 
 XrResult destroy_pico_body_tracker(XrBodyTrackerBD);
 
@@ -48,7 +49,7 @@ public:
 	};
 
 	pico_body_tracker() = default;
-	pico_body_tracker(instance & inst, XrBodyTrackerBD h);
+	pico_body_tracker(instance & inst, session & s);
 
 	size_t count() const;
 	std::optional<std::array<wivrn::from_headset::body_tracking::pose, wivrn::from_headset::body_tracking::max_tracked_poses>> locate_spaces(XrTime time, XrSpace reference);

--- a/client/xr/session.cpp
+++ b/client/xr/session.cpp
@@ -23,10 +23,7 @@
 #include "details/enumerate.h"
 #include "openxr/openxr.h"
 #include "utils/contains.h"
-#include "xr/fb_body_tracker.h"
-#include "xr/htc_body_tracker.h"
 #include "xr/instance.h"
-#include "xr/pico_body_tracker.h"
 #include "xr/system.h"
 #include <ranges>
 #include <vulkan/vulkan.h>
@@ -99,65 +96,6 @@ xr::hand_tracker xr::session::create_hand_tracker(XrHandEXT hand, XrHandJointSet
 	                .hand = hand,
 	                .handJointSet = hand_joint_set,
 	        }};
-}
-
-xr::fb_face_tracker2 xr::session::create_fb_face_tracker2()
-{
-	XrFaceTrackingDataSource2FB data_sources[1];
-	data_sources[0] = XR_FACE_TRACKING_DATA_SOURCE2_VISUAL_FB;
-
-	XrFaceTrackerCreateInfo2FB create_info{
-	        .type = XR_TYPE_FACE_TRACKER_CREATE_INFO2_FB,
-	        .next = nullptr,
-	        .faceExpressionSet = XR_FACE_EXPRESSION_SET2_DEFAULT_FB,
-	        .requestedDataSourceCount = 1,
-	        .requestedDataSources = data_sources,
-	};
-
-	XrFaceTracker2FB ft;
-
-	auto xrCreateFaceTracker2FB = inst->get_proc<PFN_xrCreateFaceTracker2FB>("xrCreateFaceTracker2FB");
-	assert(xrCreateFaceTracker2FB);
-
-	CHECK_XR(xrCreateFaceTracker2FB(id, &create_info, &ft));
-	return {*inst, ft};
-}
-
-xr::htc_face_tracker xr::session::create_htc_face_tracker(bool eye, bool lip)
-{
-	return {*inst, *this, eye, lip};
-}
-
-xr::pico_face_tracker xr::session::create_pico_face_tracker()
-{
-	return {*inst, *this};
-}
-
-xr::fb_body_tracker xr::session::create_fb_body_tracker()
-{
-	return {*inst, *this};
-}
-
-xr::htc_body_tracker xr::session::create_htc_body_tracker()
-{
-	return {*inst, *this};
-}
-
-xr::pico_body_tracker xr::session::create_pico_body_tracker()
-{
-	XrBodyTrackerCreateInfoBD create_info{
-	        .type = XR_TYPE_BODY_TRACKER_CREATE_INFO_BD,
-	        .next = nullptr,
-	        .jointSet = XR_BODY_JOINT_SET_FULL_BODY_JOINTS_BD,
-	};
-
-	XrBodyTrackerBD bt;
-
-	auto xrCreateBodyTrackerBD = inst->get_proc<PFN_xrCreateBodyTrackerBD>("xrCreateBodyTrackerBD");
-	assert(xrCreateBodyTrackerBD);
-
-	CHECK_XR(xrCreateBodyTrackerBD(id, &create_info, &bt));
-	return {*inst, bt};
 }
 
 std::vector<vk::Format> xr::session::get_swapchain_formats() const

--- a/client/xr/session.h
+++ b/client/xr/session.h
@@ -26,14 +26,8 @@
 #include <vulkan/vulkan_raii.hpp>
 #include <openxr/openxr.h>
 
-#include "fb_body_tracker.h"
-#include "fb_face_tracker2.h"
 #include "hand_tracker.h"
-#include "htc_body_tracker.h"
-#include "htc_face_tracker.h"
 #include "passthrough.h"
-#include "pico_body_tracker.h"
-#include "pico_face_tracker.h"
 #include "space.h"
 
 namespace xr
@@ -54,12 +48,6 @@ public:
 	space create_reference_space(XrReferenceSpaceType ref, const XrPosef & pose = {{0, 0, 0, 1}, {0, 0, 0}});
 	space create_action_space(XrAction action, const XrPosef & pose = {{0, 0, 0, 1}, {0, 0, 0}});
 	hand_tracker create_hand_tracker(XrHandEXT hand, XrHandJointSetEXT hand_joint_set = XR_HAND_JOINT_SET_DEFAULT_EXT);
-	fb_face_tracker2 create_fb_face_tracker2();
-	htc_face_tracker create_htc_face_tracker(bool eye, bool lip);
-	pico_face_tracker create_pico_face_tracker();
-	fb_body_tracker create_fb_body_tracker();
-	htc_body_tracker create_htc_body_tracker();
-	pico_body_tracker create_pico_body_tracker();
 
 	std::vector<vk::Format> get_swapchain_formats() const;
 


### PR DESCRIPTION
Fixes crash on startup with HTC face tracking. HTC face tracker doesn't seem to turn off when `xrDestroyFacialTrackerHTC` is called... https://discord.com/channels/1065291958328758352/1225819663024259082/1396624389159780455