### PR TITLE
Share CUDA context between all nvenc encoder instances

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -127,7 +127,11 @@ if (WIVRN_BUILD_SERVER)
 	endif()
 
 	if(WIVRN_USE_NVENC)
-		target_sources(wivrn-server PRIVATE encoder/video_encoder_nvenc.cpp)
+		target_sources(
+			wivrn-server
+			PRIVATE encoder/video_encoder_nvenc.cpp
+				encoder/video_encoder_nvenc_shared_state.cpp
+			)
 	endif()
 
 	if(WIVRN_USE_VAAPI)

--- a/server/encoder/video_encoder_nvenc.h
+++ b/server/encoder/video_encoder_nvenc.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "video_encoder.h"
+#include "video_encoder_nvenc_shared_state.h"
 #include <array>
 #include <ffnvcodec/dynlink_cuda.h>
 #include <ffnvcodec/dynlink_loader.h>
@@ -31,22 +32,13 @@ namespace wivrn
 
 class video_encoder_nvenc : public video_encoder
 {
-public:
-	struct deleter
-	{
-		void operator()(CudaFunctions * fn);
-		void operator()(NvencFunctions * fn);
-	};
-
 private:
 	wivrn_vk_bundle & vk;
 	// relevant part of the input image to encode
 	vk::Rect2D rect;
 
-	std::unique_ptr<CudaFunctions, deleter> cuda_fn;
-	std::unique_ptr<NvencFunctions, deleter> nvenc_fn;
-	NV_ENCODE_API_FUNCTION_LIST fn;
-	CUcontext cuda;
+	std::shared_ptr<video_encoder_nvenc_shared_state> shared_state;
+
 	void * session_handle = nullptr;
 	NV_ENC_OUTPUT_PTR bitstreamBuffer;
 

--- a/server/encoder/video_encoder_nvenc_shared_state.cpp
+++ b/server/encoder/video_encoder_nvenc_shared_state.cpp
@@ -1,0 +1,100 @@
+/*
+ * WiVRn VR streaming
+ * Copyright (C) 2022-2024  Guillaume Meunier <guillaume.meunier@centraliens.net>
+ * Copyright (C) 2022-2024  Patrick Nicolas <patricknicolas@laposte.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "video_encoder_nvenc_shared_state.h"
+#include "util/u_logging.h"
+
+#include <bits/unique_lock.h>
+
+void video_encoder_nvenc_shared_state::deleter::operator()(CudaFunctions * fn)
+{
+	cuda_free_functions(&fn);
+}
+void video_encoder_nvenc_shared_state::deleter::operator()(NvencFunctions * fn)
+{
+	nvenc_free_functions(&fn);
+}
+
+#define NVENC_CHECK_NOENCODER(x)                                                            \
+	do                                                                                  \
+	{                                                                                   \
+		NVENCSTATUS status = x;                                                     \
+		if (status != NV_ENC_SUCCESS)                                               \
+		{                                                                           \
+			U_LOG_E("NVENC Init Error: %s:%d: %d", __FILE__, __LINE__, status); \
+			throw std::runtime_error("nvenc init error");                       \
+		}                                                                           \
+	} while (0)
+
+#define CU_CHECK(x)                                                                                                \
+	do                                                                                                         \
+	{                                                                                                          \
+		CUresult status = x;                                                                               \
+		if (status != CUDA_SUCCESS)                                                                        \
+		{                                                                                                  \
+			const char * error_string;                                                                 \
+			cuda_fn->cuGetErrorString(status, &error_string);                                          \
+			U_LOG_E("CUDA Init Error: %s:%d: %s (%d)", __FILE__, __LINE__, error_string, (int)status); \
+			throw std::runtime_error(std::string("CUDA init error: ") + error_string);                 \
+		}                                                                                                  \
+	} while (0)
+
+std::shared_ptr<video_encoder_nvenc_shared_state> video_encoder_nvenc_shared_state::get()
+{
+	static std::weak_ptr<video_encoder_nvenc_shared_state> instance;
+	static std::mutex m;
+	std::unique_lock lock(m);
+	auto s = instance.lock();
+	if (s)
+		return s;
+	s.reset(new video_encoder_nvenc_shared_state());
+	instance = s;
+	return s;
+}
+
+video_encoder_nvenc_shared_state::video_encoder_nvenc_shared_state()
+{
+	CudaFunctions * tmp_cuda_fn = nullptr;
+	if (cuda_load_functions(&tmp_cuda_fn, nullptr))
+	{
+		throw std::runtime_error("Failed to load CUDA functions");
+	}
+	cuda_fn.reset(tmp_cuda_fn);
+
+	NvencFunctions * tmp_nvenc_fn = nullptr;
+	if (nvenc_load_functions(&tmp_nvenc_fn, nullptr))
+	{
+		throw std::runtime_error("Failed to load nvenc functions");
+	}
+	nvenc_fn.reset(tmp_nvenc_fn);
+
+	CU_CHECK(cuda_fn->cuInit(0));
+	CU_CHECK(cuda_fn->cuCtxCreate(&cuda, 0, 0));
+
+	fn.version = NV_ENCODE_API_FUNCTION_LIST_VER;
+	NVENC_CHECK_NOENCODER(nvenc_fn->NvEncodeAPICreateInstance(&fn));
+}
+
+video_encoder_nvenc_shared_state::~video_encoder_nvenc_shared_state()
+{
+	if (cuda)
+	{
+		cuda_fn->cuCtxDestroy(cuda);
+	}
+}

--- a/server/encoder/video_encoder_nvenc_shared_state.h
+++ b/server/encoder/video_encoder_nvenc_shared_state.h
@@ -1,0 +1,50 @@
+/*
+ * WiVRn VR streaming
+ * Copyright (C) 2022-2024  Guillaume Meunier <guillaume.meunier@centraliens.net>
+ * Copyright (C) 2022-2024  Patrick Nicolas <patricknicolas@laposte.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include <ffnvcodec/dynlink_cuda.h>
+#include <ffnvcodec/dynlink_loader.h>
+#include <ffnvcodec/nvEncodeAPI.h>
+
+class video_encoder_nvenc_shared_state
+{
+public:
+	struct deleter
+	{
+		void operator()(CudaFunctions * fn);
+		void operator()(NvencFunctions * fn);
+	};
+
+	static std::shared_ptr<video_encoder_nvenc_shared_state> get();
+	std::unique_ptr<CudaFunctions, deleter> cuda_fn;
+	std::unique_ptr<NvencFunctions, deleter> nvenc_fn;
+	NV_ENCODE_API_FUNCTION_LIST fn = {};
+	CUcontext cuda = nullptr;
+
+	video_encoder_nvenc_shared_state();
+	~video_encoder_nvenc_shared_state();
+
+	video_encoder_nvenc_shared_state(const video_encoder_nvenc_shared_state &) = delete;
+	video_encoder_nvenc_shared_state & operator=(const video_encoder_nvenc_shared_state &) = delete;
+	video_encoder_nvenc_shared_state(video_encoder_nvenc_shared_state &&) = delete;
+	video_encoder_nvenc_shared_state & operator=(video_encoder_nvenc_shared_state &&) = delete;
+};


### PR DESCRIPTION
Hey, this PR fixes the huge VRAM usage when using split encoding with NVENC.

The old implementation was creating a whole new CUDA context for every single encoder instance, which was eating up an extra ~500 MiB of VRAM per slice. I've refactored this so that all NVENC encoders now share a single, global context. This makes the overhead for adding more encoders minimal and stops the unreasonable memory consumption.

The results are pretty dramatic. In my tests on an RTX 4080 Super (AV1 @ 130% on Quest 3 with a 150 Mbit/s bitrate), the VRAM usage dropped significantly:

- **Before (master):**
  - 1 encoder: **1590 MiB**
  - 3 encoders: **2652 MiB**
- **After (this PR):**
  - 1 encoder: **847 MiB**
  - 3 encoders: **916 MiB**

Besides the obvious memory savings, everything feels much smoother now and latency seems to be in a very good spot.

---
**A quick note:**
The fix works and the results are great, but I'd really appreciate some feedback on the implementation itself. My main language is Kotlin and to be honest, I find C++ a bit of a struggle. I'm not that familiar with common C++ practices, as a lot of it feels a bit unpleasant and unintuitive to me.

Any advice from a C++ expert on how this could be improved or written more idiomatically would be great. Thanks.