### PR TITLE
Fix wrong refresh rate shown on fresh config

### DIFF
--- a/client/scenes/lobby_gui.cpp
+++ b/client/scenes/lobby_gui.cpp
@@ -799,7 +799,7 @@ void scenes::lobby::gui_settings()
 		const auto & refresh_rates = session.get_refresh_rates();
 		if (not refresh_rates.empty())
 		{
-			float active_rate = config.preferred_refresh_rate.value_or(refresh_rates.back());
+			float active_rate = config.preferred_refresh_rate.value_or(session.get_current_refresh_rate());
 			if (ImGui::BeginCombo(_S("Refresh rate"), active_rate ? fmt::format("{}", active_rate).c_str() : _cS("automatic refresh rate", "Automatic")))
 			{
 				if (ImGui::Selectable(_cS("automatic refresh rate", "Automatic"), config.preferred_refresh_rate == 0, ImGuiSelectableFlags_SelectOnRelease))


### PR DESCRIPTION
The config screen currently uses the highest reported refresh rate if no preferred refresh rate is set, which it will be with a fresh config.
https://github.com/WiVRn/WiVRn/blob/master/client/scenes/lobby_gui.cpp#L802

But it gets set to 0 by default here (so default for platform...?).
https://github.com/WiVRn/WiVRn/blob/master/client/scenes/lobby.cpp#L936 

On my Quest 3, this means the refresh rate defaults to 72Hz even though the menu shows 120Hz.