### PR TITLE
Add missing stdlib includes to improve portability

### DIFF
--- a/common/utils/load_icon.cpp
+++ b/common/utils/load_icon.cpp
@@ -26,6 +26,7 @@
 #include <png.h>
 #include <span>
 #include <unordered_map>
+#include <bit>
 
 namespace
 {

--- a/common/utils/load_icon.cpp
+++ b/common/utils/load_icon.cpp
@@ -20,13 +20,13 @@
 
 #include <archive.h>
 #include <archive_entry.h>
+#include <bit>
 #include <cairo.h>
 #include <fstream>
 #include <librsvg/rsvg.h>
 #include <png.h>
 #include <span>
 #include <unordered_map>
-#include <bit>
 
 namespace
 {

--- a/dashboard/wivrn_server.cpp
+++ b/dashboard/wivrn_server.cpp
@@ -29,6 +29,7 @@
 #include <cassert>
 #include <memory>
 #include <nlohmann/json.hpp>
+#include <unistd.h>
 
 #if WIVRN_CHECK_CAPSYSNICE
 #include <sys/capability.h>

--- a/server/driver/wivrn_foveation.cpp
+++ b/server/driver/wivrn_foveation.cpp
@@ -34,6 +34,7 @@
 #include <vulkan/vulkan_raii.hpp>
 #include <vulkan/vulkan_structs.hpp>
 #include <openxr/openxr.h>
+#include <charconv>
 
 extern const std::map<std::string, std::vector<uint32_t>> shaders;
 

--- a/server/driver/wivrn_foveation.cpp
+++ b/server/driver/wivrn_foveation.cpp
@@ -28,13 +28,13 @@
 #include "xrt/xrt_defines.h"
 
 #include <array>
+#include <charconv>
 #include <cmath>
 #include <map>
 #include <ranges>
 #include <vulkan/vulkan_raii.hpp>
 #include <vulkan/vulkan_structs.hpp>
 #include <openxr/openxr.h>
-#include <charconv>
 
 extern const std::map<std::string, std::vector<uint32_t>> shaders;
 

--- a/server/driver/wivrn_foveation.h
+++ b/server/driver/wivrn_foveation.h
@@ -25,8 +25,8 @@
 #include "xrt/xrt_device.h"
 
 #include "utils/singleton.h"
-#include <vulkan/vulkan_raii.hpp>
 #include <mutex>
+#include <vulkan/vulkan_raii.hpp>
 
 struct render_resources;
 

--- a/server/driver/wivrn_foveation.h
+++ b/server/driver/wivrn_foveation.h
@@ -26,6 +26,7 @@
 
 #include "utils/singleton.h"
 #include <vulkan/vulkan_raii.hpp>
+#include <mutex>
 
 struct render_resources;
 

--- a/server/encoder/encoder_settings.cpp
+++ b/server/encoder/encoder_settings.cpp
@@ -24,11 +24,11 @@
 #include "video_encoder.h"
 
 #include "wivrn_packets.h"
+#include <charconv>
 #include <cmath>
 #include <magic_enum.hpp>
 #include <string>
 #include <vulkan/vulkan.h>
-#include <charconv>
 
 #include "wivrn_config.h"
 

--- a/server/encoder/encoder_settings.cpp
+++ b/server/encoder/encoder_settings.cpp
@@ -28,6 +28,7 @@
 #include <magic_enum.hpp>
 #include <string>
 #include <vulkan/vulkan.h>
+#include <charconv>
 
 #include "wivrn_config.h"
 


### PR DESCRIPTION
g++/libstdc++ tends to allow using functionality from stdlib headers not specifically included (e.g. included transitively through other stdlib headers). This, however, is non standard, so adding explicit includes for them makes WiVRn more portable to other toolchains.

See #498 for more info