### PR TITLE
Change bitrate and fps at runtime on NVENC

### DIFF
--- a/server/encoder/video_encoder_nvenc.h
+++ b/server/encoder/video_encoder_nvenc.h
@@ -53,9 +53,11 @@ private:
 	std::array<in_t, num_slots> in;
 
 	float fps;
+	uint64_t bitrate;
 	int bytesPerPixel = 1;
 
-	NV_ENC_RC_PARAMS get_rc_params(uint64_t bitrate);
+	NV_ENC_RC_PARAMS get_rc_params(uint64_t bitrate, float framerate);
+	void set_init_params_fps(float framerate);
 
 public:
 	video_encoder_nvenc(wivrn_vk_bundle & vk, encoder_settings & settings, float fps, uint8_t stream_idx);


### PR DESCRIPTION
Continues #173 and Implements #539.
Works great and helps me to find the best bitrates really quickly. 

I'm only concerned whether I dealt with narrowing conversion in `get_rc_params` the right way or not.

Also I saw that fps can be changed on the fly and wanted to add that next, but unsure where it is set from?
