### PR TITLE
Send session state on connection

### DIFF
--- a/client/scenes/stream.cpp
+++ b/client/scenes/stream.cpp
@@ -304,6 +304,10 @@ std::shared_ptr<scenes::stream> scenes::stream::create(std::unique_ptr<wivrn_ses
 		return info;
 	}());
 
+	self->network_session->send_control(from_headset::session_state_changed{
+	        .state = application::get_session_state(),
+	});
+
 	if (self->instance.has_extension(XR_KHR_VISIBILITY_MASK_EXTENSION_NAME))
 	{
 		for (uint8_t view = 0; view < view_count; ++view)


### PR DESCRIPTION
On Quest, quitting WiVRn from the system menu while connected, then opening the app again and reconnecting wouldn't send the session state to the server, causing compositors to keep dropping frames until the session state is changed again (e.g. by opening the system menu again).