### PR TITLE
Make sure ipc server is initialised before accessing it

### DIFF
--- a/server/driver/wivrn_session.cpp
+++ b/server/driver/wivrn_session.cpp
@@ -672,6 +672,9 @@ void wivrn_session::operator()(from_headset::visibility_mask_changed && mask)
 void wivrn_session::operator()(from_headset::session_state_changed && event)
 {
 	U_LOG_I("Session state changed: %s", xr::to_string(event.state));
+	if (!inst.server)
+		return;
+
 	bool visible, focused;
 	switch (event.state)
 	{
@@ -785,6 +788,8 @@ void wivrn_session::operator()(const from_headset::start_app & request)
 
 void wivrn_session::operator()(const from_headset::get_running_applications &)
 {
+	if (!inst.server)
+		return;
 	scoped_lock lock(inst.server->global_state.lock);
 	to_headset::running_applications msg{};
 	for (auto & t: inst.server->threads)
@@ -809,6 +814,8 @@ void wivrn_session::operator()(const from_headset::get_running_applications &)
 
 void wivrn_session::operator()(const from_headset::set_active_application & req)
 {
+	if (!inst.server)
+		return;
 	ipc_server_set_active_client(inst.server, req.id);
 	ipc_server_update_state(inst.server);
 	// Send a refreshed application list
@@ -817,6 +824,8 @@ void wivrn_session::operator()(const from_headset::set_active_application & req)
 
 void wivrn_session::operator()(const from_headset::stop_application & req)
 {
+	if (!inst.server)
+		return;
 	scoped_lock lock(inst.server->global_state.lock);
 	for (auto & t: inst.server->threads)
 	{
@@ -1021,6 +1030,8 @@ void wivrn_session::reconnect()
 
 void wivrn_session::poll_session_loss()
 {
+	if (!inst.server)
+		return;
 	auto locked = session_loss.lock();
 	auto now = os_monotonic_get_ns();
 	if (locked->empty())


### PR DESCRIPTION
From Discord (@ozzy_helix_):
```
Thread 2.38 "wivrn-server" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7f410b8046c0 (LWP 23839)]
0x00007f414a299f64 in pthread_mutex_lock () from /usr/lib/libc.so.6
(gdb) bt
#0  0x00007f414a299f64 in pthread_mutex_lock () at /usr/lib/libc.so.6
#1  0x000055f86b0a0834 in os_mutex_lock (om=<optimized out>)
    at /home/ozzy/.local/share/envision/5dbbbb96-6e4d-4972-b99a-d475abda62c7/xrservice/build/_deps/monado-src/src/xrt/auxiliary/os/os_threading.h:89
#2  wivrn::scoped_lock::scoped_lock (this=<synthetic pointer>, mutex=<optimized out>)
    at /home/ozzy/.local/share/envision/5dbbbb96-6e4d-4972-b99a-d475abda62c7/xrservice/server/./utils/scoped_lock.h:35
#3  wivrn::wivrn_session::operator() (this=0x55f89bf00b30, event=...)
    at /home/ozzy/.local/share/envision/5dbbbb96-6e4d-4972-b99a-d475abda62c7/xrservice/server/driver/wivrn_session.cpp:691
#4  0x000055f86b0a9492 in std::__do_visit<std::__detail::__variant::__deduce_visit_result<void>, wivrn::wivrn_session&, std::variant<wivrn::from_headset::crypto_handshake, wivrn::from_headset::pin_check_1, wivrn::from_headset::pin_check_3, wivrn::from_headset::headset_info_packet, wivrn::from_headset::feedback, wivrn::audio_data, wivrn::from_headset::handshake, wivrn::from_headset::tracking, wivrn::from_headset::trackings, wivrn::from_headset::derived_pose, wivrn::from_headset::hand_tracking, wivrn::from_headset::body_tracking, wivrn::from_headset::inputs, wivrn::from_headset::timesync_response, wivrn::from_headset::battery, wivrn::from_headset::visibility_mask_changed, wivrn::from_headset::refresh_rate_changed, wivrn::from_headset::session_state_changed, wivrn::from_headset::user_presence_changed, wivrn::from_headset::override_foveation_center, wivrn::from_headset::get_application_list, wivrn::from_headset::start_app, wivrn::from_headset::get_running_applications, wivrn::from_headset::set_active_application, wivrn::from_headset::stop_application> > (__visitor=...)
    at /usr/include/c++/15.2.1/variant:883
#5  std::visit<wivrn::wivrn_session&, std::variant<wivrn::from_headset::crypto_handshake, wivrn::from_headset::pin_check_1, wivrn::from_headset::pin_check_3, wivrn::from_headset::headset_info_packet, wivrn::from_headset::feedback, wivrn::audio_data, wivrn::from_headset::handshake, wivrn::from_headset::tracking, wivrn::from_headset::trackings, wivrn::from_headset::derived_pose, wivrn::from_headset::hand_tracking, wivrn::from_headset::body_tracking, wivrn::from_headset::inputs, wivrn::from_headset::timesync_response, wivrn::from_headset::battery, wivrn::from_headset::visibility_mask_changed, wivrn::from_headset::refresh_rate_changed, wivrn::from_headset::session_state_changed, wivrn::from_headset::user_presence_changed, wivrn::from_headset::override_foveation_center, wivrn::from_headset::get_application_list, wivrn::from_headset::start_app, wivrn::from_headset::get_running_applications, wivrn::from_headset::set_active_application, wivrn::from_headset::stop_application> >
    (__visitor=...) at /usr/include/c++/15.2.1/variant:1954
#6  wivrn::wivrn_connection::poll<wivrn::wivrn_session&> (this=0x7f412c02c220, visitor=..., timeout=timeout@entry=20)
    at /home/ozzy/.local/share/envision/5dbbbb96-6e4d-4972-b99a-d475abda62c7/xrservice/server/driver/wivrn_connection.h:161
#7  0x000055f86b0a97b9 in wivrn::wivrn_session::run (this=0x55f89bf00b30, stop=...)
    at /usr/include/c++/15.2.1/bits/unique_ptr.h:193
#8  0x000055f86b0a9a7a in operator()<std::stop_token> (__closure=<optimized out>, stop_token=...)
    at /home/ozzy/.local/share/envision/5dbbbb96-6e4d-4972-b99a-d475abda62c7/xrservice/server/driver/wivrn_session.cpp:358
#9  std::__invoke_impl<void, wivrn::wivrn_session::create_session(std::unique_ptr<wivrn::wivrn_connection>, wivrn::instance&, u_system&, xrt_system_devices**, xrt_space_overseer**, xrt_system_compositor**)::<lambda(auto:67)>, std::stop_token>
    (__f=<optimized out>) at /usr/include/c++/15.2.1/bits/invoke.h:63
#10 std::__invoke<wivrn::wivrn_session::create_session(std::unique_ptr<wivrn::wivrn_connection>, wivrn::instance&, u_system&, xrt_system_devices**, xrt_space_overseer**, xrt_system_compositor**)::<lambda(auto:67)>, std::stop_token>
    (__fn=<optimized out>) at /usr/include/c++/15.2.1/bits/invoke.h:98
#11 std::thread::_Invoker<std::tuple<wivrn::wivrn_session::create_session(std::unique_ptr<wivrn::wivrn_connection>, wivrn::instance&, u_system&, xrt_system_devices**, xrt_space_overseer**, xrt_system_compositor**)::<lambda(auto:67)>, std::stop_token> >::_M_invoke<0, 1> (this=<optimized out>) at /usr/include/c++/15.2.1/bits/std_thread.h:303
#12 std::thread::_Invoker<std::tuple<wivrn::wivrn_session::create_session(std::unique_ptr<wivrn::wivrn_connection>, wivrn::instance&, u_system&, xrt_system_devices**, xrt_space_overseer**, xrt_system_compositor**)::<lambda(auto:67)>, std::stop_token> >::operator() (this=<optimized out>) at /usr/include/c++/15.2.1/bits/std_thread.h:310
#13 std::thread::_State_impl<std::thread::_Invoker<std::tuple<wivrn::wivrn_session::create_session(std::unique_ptr<wivrn::wivrn_connection>, wivrn::instance&, u_system&, xrt_system_devices**, xrt_space_overseer**, xrt_system_compositor**)::<lambda(auto:67)>, std::stop_token> > >::_M_run(void) (this=<optimized out>) at /usr/include/c++/15.2.1/bits/std_thread.h:255
#14 0x00007f414a6e55a4 in std::execute_native_thread_routine (__p=0x55f89cc2b7f0)
    at /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++11/thread.cc:104
#15 0x00007f414a2969cb in ??? () at /usr/lib/libc.so.6
#16 0x00007f414a31aa0c in ??? () at /usr/lib/libc.so.6
```