### PR TITLE
fix: correct typo in Japanese text (変わり → 代わり)

### DIFF
--- a/locale/ja/wivrn-dashboard.po
+++ b/locale/ja/wivrn-dashboard.po
@@ -860,7 +860,7 @@ msgid ""
 "WiVRn entirely replaces SteamVR, you should not start SteamVR while WiVRn is "
 "running."
 msgstr ""
-"WiVRnはSteamVRの変わりに使うものです。両方を同時に走らせないように気をつけま"
+"WiVRnはSteamVRの代わりに使うものです。両方を同時に走らせないように気をつけま"
 "しょう。"
 
 #: dashboard/qml/WizardPage.qml:359


### PR DESCRIPTION
## Summary
Fixed typo in Japanese text: 変わり → 代わり (alternative/substitute)

The correct word for "alternative" is "代わり", not "変わり".