### PR TITLE
Extend session loss timer

### DIFF
--- a/server/driver/wivrn_session.cpp
+++ b/server/driver/wivrn_session.cpp
@@ -877,7 +877,7 @@ void wivrn_session::operator()(const from_headset::stop_application & req)
 		if (t.ics.client_state.id == req.id)
 		{
 			U_LOG_I("Notify session loss pending for %s", t.ics.client_state.info.application_name);
-			auto when = os_monotonic_get_ns() + 200 * U_TIME_1MS_IN_NS;
+			auto when = os_monotonic_get_ns() + 10l * U_TIME_1S_IN_NS;
 			xrt_syscomp_notify_loss_pending(system_compositor, t.ics.xc, when);
 			session_loss.lock()->emplace(when, req.id);
 			break;


### PR DESCRIPTION
Give applications a reasonable amount of time to quit before losing the instance.

Applications may want to perform some tasks before leaving, e.g. VRChat does a fade out, leaves the world, and then deinits everything and closes, which may take too much time for the 200ms timeout. I feel like 10 seconds is reasonable, though 5 seconds is probably fine as well.