### PR TITLE
Fix text for 10-bit checkbox in SettingsPage.qml

### DIFF
--- a/dashboard/qml/SettingsPage.qml
+++ b/dashboard/qml/SettingsPage.qml
@@ -207,7 +207,7 @@ Kirigami.ScrollablePage {
                 }
                 Controls.CheckBox {
                     enabled: config.can10bit
-                    text: i18n("10-bit")
+                    text: i18n("10 bits")
                     checked: config.tenbit
                     onCheckedChanged: config.tenbit = checked
                 }

--- a/locale/es/wivrn-dashboard.po
+++ b/locale/es/wivrn-dashboard.po
@@ -531,8 +531,8 @@ msgstr "AV1"
 
 #: dashboard/qml/SettingsPage.qml:210
 #, kde-format
-msgid "10-bits"
-msgstr "10-bits"
+msgid "10 bits"
+msgstr "10 bits"
 
 #: dashboard/qml/SettingsPage.qml:215
 #, kde-format

--- a/locale/fr/wivrn-dashboard.po
+++ b/locale/fr/wivrn-dashboard.po
@@ -526,7 +526,7 @@ msgstr "AV1"
 
 #: dashboard/qml/SettingsPage.qml:210
 #, kde-format
-msgid "10-bits"
+msgid "10 bits"
 msgstr "10 bits"
 
 #: dashboard/qml/SettingsPage.qml:215

--- a/locale/ja/wivrn-dashboard.po
+++ b/locale/ja/wivrn-dashboard.po
@@ -514,7 +514,7 @@ msgstr "AV1"
 
 #: dashboard/qml/SettingsPage.qml:210
 #, kde-format
-msgid "10-bits"
+msgid "10 bits"
 msgstr "10ビット"
 
 #: dashboard/qml/SettingsPage.qml:215

--- a/locale/pt_BR/wivrn-dashboard.po
+++ b/locale/pt_BR/wivrn-dashboard.po
@@ -532,8 +532,8 @@ msgstr "AV1"
 
 #: dashboard/qml/SettingsPage.qml:210
 #, kde-format
-msgid "10-bits"
-msgstr "10-bits"
+msgid "10 bits"
+msgstr "10 bits"
 
 #: dashboard/qml/SettingsPage.qml:215
 #, kde-format

--- a/locale/ru/wivrn-dashboard.po
+++ b/locale/ru/wivrn-dashboard.po
@@ -531,7 +531,7 @@ msgstr "AV1"
 
 #: dashboard/qml/SettingsPage.qml:217
 #, kde-format
-msgid "10-bits"
+msgid "10 bits"
 msgstr "10-бит"
 
 #: dashboard/qml/SettingsPage.qml:221

--- a/locale/tr/wivrn-dashboard.po
+++ b/locale/tr/wivrn-dashboard.po
@@ -529,7 +529,7 @@ msgstr "AV1"
 
 #: dashboard/qml/SettingsPage.qml:210
 #, kde-format
-msgid "10-bits"
+msgid "10 bits"
 msgstr "10-bit"
 
 #: dashboard/qml/SettingsPage.qml:215

--- a/locale/zh_CN/wivrn-dashboard.po
+++ b/locale/zh_CN/wivrn-dashboard.po
@@ -519,7 +519,7 @@ msgstr "AV1"
 
 #: dashboard/qml/SettingsPage.qml:210
 #, kde-format
-msgid "10-bits"
+msgid "10 bits"
 msgstr "10 位编码"
 
 #: dashboard/qml/SettingsPage.qml:215


### PR DESCRIPTION
It could also say "10 bits", but not "10-bits".

Note: this will affect several localisations that used "10-bits".