### PR TITLE
Polish Simplified Chinese translation

### DIFF
--- a/locale/zh_CN/wivrn-dashboard.po
+++ b/locale/zh_CN/wivrn-dashboard.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: WiVRn-dashboard\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-11-21 05:41+0800\n"
-"PO-Revision-Date: 2025-11-29 23:03+0800\n"
+"PO-Revision-Date: 2025-11-30 17:31+0800\n"
 "Last-Translator: BERADQ <adqber123@outlook.com>\n"
 "Language-Team: Chinese (China)\n"
 "Language: zh_CN\n"
@@ -315,13 +315,13 @@ msgstr "开启服务器日志"
 #, kde-format
 msgctxt "whether the server is running, displayed in front of a checkbox"
 msgid "Running"
-msgstr "运行中"
+msgstr "运行"
 
 #: dashboard/qml/Main.qml:279
 #, kde-format
 msgctxt "whether pairing is enabled, displayed in front of a checkbox"
 msgid "Pairing"
-msgstr "配对中"
+msgstr "配对"
 
 #: dashboard/qml/Main.qml:292
 #, kde-format
@@ -586,12 +586,12 @@ msgstr ""
 #: dashboard/qml/SettingsPage.qml:259
 #, kde-format
 msgid "Custom adb location"
-msgstr "自定义 adb 位置"
+msgstr "自定义 adb 路径"
 
 #: dashboard/qml/SettingsPage.qml:270
 #, kde-format
 msgid "Adb location:"
-msgstr "adb 位置："
+msgstr "adb 路径："
 
 #: dashboard/qml/SettingsPage.qml:279
 #, kde-format
@@ -875,7 +875,7 @@ msgstr "重要信息"
 msgid ""
 "WiVRn entirely replaces SteamVR, you should not start SteamVR while WiVRn is "
 "running."
-msgstr "WiVRn 完全取代了 SteamVR，在 WiVRn 运行时，請勿啟動 SteamVR"
+msgstr "WiVRn 完全取代了 SteamVR，在 WiVRn 运行时，请勿启动 SteamVR"
 
 #: dashboard/qml/WizardPage.qml:359
 #, kde-format

--- a/locale/zh_CN/wivrn.po
+++ b/locale/zh_CN/wivrn.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: WiVRn\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-11-18 04:03+0800\n"
-"PO-Revision-Date: 2025-11-30 17:13+0800\n"
+"PO-Revision-Date: 2025-11-30 17:24+0800\n"
 "Last-Translator: BERADQ <adqber123@outlook.com>\n"
 "Language-Team: Chinese (China)\n"
 "Language: zh_CN\n"
@@ -117,7 +117,7 @@ msgstr "身份识别码"
 
 #: client/scenes/lobby_gui.cpp:192
 msgid "Input the PIN displayed on the dashboard"
-msgstr "请输入控制面板上显示的身份识别码"
+msgstr "请输入显示在控制面板上的身份识别码"
 
 #: client/scenes/lobby_gui.cpp:282
 msgid "Name"
@@ -323,7 +323,7 @@ msgid ""
 "Useful when the input resolution is high compared to the headset display"
 msgstr ""
 "减少高对比度边缘的闪烁。\n"
-"当输入分辨率高于头显原生分辨率时很有用"
+"当串流分辨率高于头显原生分辨率时很有用"
 
 #: client/scenes/lobby_gui.cpp:834 client/scenes/stream_gui.cpp:493
 msgid "Sharpening"
@@ -335,7 +335,7 @@ msgid ""
 "Useful when the input resolution is low compared to the headset display"
 msgstr ""
 "改善高对比边缘的清晰度并抵消模糊。\n"
-"当输入分辨率低于头显原生分辨率时很有用"
+"当串流分辨率低于头显原生分辨率时很有用"
 
 #: client/scenes/lobby_gui.cpp:1038 client/scenes/lobby_gui.cpp:1046
 #: client/scenes/stream_gui.cpp:172 client/scenes/stream_gui.cpp:374
@@ -503,8 +503,7 @@ msgid ""
 "Curl error when downloading {}\n"
 "{}: {}"
 msgstr ""
-"Curl \n"
-"时发生错误 {}\n"
+"通过 Curl 下载时发生了错误 {}\n"
 "{}：{}"
 
 #: client/scenes/lobby_gui_customize.cpp:552
@@ -593,7 +592,7 @@ msgstr "已预测"
 #: client/scenes/stream_gui.cpp:345
 #, c++-format
 msgid "Estimated motion to photons latency: {}ms"
-msgstr "估计从运动到显示延迟: {}毫秒"
+msgstr "估计从运动到显示延迟: {}ms"
 
 #: client/scenes/stream_gui.cpp:352
 msgid "Press the grip button to move the window"
@@ -618,12 +617,12 @@ msgstr "启用"
 #: client/scenes/stream_gui.cpp:532 client/scenes/stream_gui.cpp:579
 #, c++-format
 msgid "Height {:.1f} deg"
-msgstr "高度 {:.1f} 度"
+msgstr "俯仰 {:.1f}°"
 
 #: client/scenes/stream_gui.cpp:533 client/scenes/stream_gui.cpp:580
 #, c++-format
 msgid "Distance {:.2f} m"
-msgstr "距离 {:.2f} 米"
+msgstr "距离 {:.2f}m"
 
 #: client/scenes/stream_gui.cpp:534
 msgid "Default"


### PR DESCRIPTION
Corrected a mistakenly typed traditional Chinese character. Optimized the translation of several words to better align with their contextual semantics.