### PR TITLE
Improve IDR handling and ignore dropped non-ref frames

### DIFF
--- a/server/encoder/idr_handler.h
+++ b/server/encoder/idr_handler.h
@@ -55,6 +55,7 @@ class default_idr_handler : public idr_handler
 		uint64_t first_p;
 	};
 	std::variant<need_idr, wait_idr_feedback, idr_received, running> state;
+	std::vector<uint64_t> non_ref_frames{512, uint64_t(-1)};
 
 public:
 	enum class frame_type
@@ -66,6 +67,8 @@ public:
 	void on_feedback(const from_headset::feedback &) override;
 	void reset() override;
 	bool should_skip(uint64_t frame_id) override;
+	void set_non_ref(uint64_t frame_index);
+	bool is_non_ref_frame(uint64_t frame_index);
 	frame_type get_type(uint64_t frame_index);
 };
 } // namespace wivrn

--- a/server/encoder/video_encoder_nvenc.cpp
+++ b/server/encoder/video_encoder_nvenc.cpp
@@ -504,6 +504,9 @@ std::optional<video_encoder::data> video_encoder_nvenc::encode(uint8_t slot, uin
 	};
 	NVENC_CHECK(shared_state->fn.nvEncLockBitstream(session_handle, &buf_lock_params));
 
+	if (buf_lock_params.pictureType == NV_ENC_PIC_TYPE_NONREF_P)
+		idr_handler.set_non_ref(frame_index);
+
 	CU_CHECK(shared_state->cuda_fn->cuCtxPopCurrent(NULL));
 	return data{
 	        .encoder = this,


### PR DESCRIPTION
- Handle dropped IDR frames by immediately transitioning back to `need_idr` state.
- Track non-reference P-frames in `video_encoder_nvenc` and prevent them from triggering unnecessary IDR requests when dropped.
- Add a timeout log for the IDR feedback.