### PR TITLE
Fix setting active runtime in Flatpak

### DIFF
--- a/server/active_runtime.cpp
+++ b/server/active_runtime.cpp
@@ -49,7 +49,7 @@ std::vector<std::filesystem::path> active_runtime::manifest_path()
 	const std::filesystem::path prefix = "openxr_wivrn";
 	// Check if in a flatpak
 	if (auto path = flatpak_key(flatpak::section::instance, "app-path"))
-		return filter_files(*path / location, prefix);
+		return {*path / location / "openxr_wivrn.json"};
 
 	// Check if running from build directory
 	auto exe = std::filesystem::read_symlink("/proc/self/exe");


### PR DESCRIPTION
Fixes 8940220fc266ce5d98fa3ebc7b856e9f70833b43
`[2025-12-19T01:09:39.781] filesystem error: directory iterator cannot open directory: No such file or directory [/var/lib/flatpak/app/io.github.wivrn.wivrn/x86_64/master/d80cb1fa4776157c948e1aa1562d60238ce3c33e733b51c6952f77fa530e4ee4/files/share/openxr/1]`
