### PR TITLE
Add controller offsets for Pico Neo 3

### DIFF
--- a/client/hardware.cpp
+++ b/client/hardware.cpp
@@ -420,18 +420,18 @@ std::pair<glm::vec3, glm::quat> controller_offset(std::string_view profile, xr::
 			default:
 				break;
 		}
-	
+
 	else if (profile == "pico-neo3")
 		switch (space)
 		{
 			case xr::spaces::grip_left:
 			case xr::spaces::grip_right:
 				return {{0, 0.005, -0.051}, glm::angleAxis(glm::radians(-29.400f), glm::vec3{1, 0, 0})};
-			
+
 			default:
 				break;
 		}
-	
+
 	else if (profile == "samsung-galaxyxr")
 		switch (space)
 		{


### PR DESCRIPTION
Added lobby offsets for Pico Neo 3 controllers.
They don't match up exactly with the controller's physical position but are close to the ones seen in Pico OS.
<img width="651" height="682" alt="pico-offset" src="https://github.com/user-attachments/assets/97512ab4-35c4-451d-abde-4f7d4a3dbcee" />
