### PR TITLE
Fix infinite loop in find_dir when reaching root directory

### DIFF
--- a/server/main.cpp
+++ b/server/main.cpp
@@ -146,12 +146,10 @@ static void append_delim(std::string & to, std::string_view what, char delim)
 // if it can't be found, return the full path
 static std::filesystem::path find_dir(const std::filesystem::path & d, const std::filesystem::path & needle)
 {
-	for (auto copy = d; ; copy = copy.parent_path())
+	for (auto copy = d; copy != copy.parent_path(); copy = copy.parent_path())
 	{
 		if (copy.filename() == needle)
 			return copy;
-		if (!copy.has_parent_path() || copy == copy.parent_path())
-			break;
 	}
 	return d;
 }


### PR DESCRIPTION
The previous loop condition `not copy.empty()` would never terminate at the filesystem root since root paths (e.g., "/" or "C:\") are never empty and their parent_path() returns themselves.