### PR TITLE
Fix pipewire sink setup

### DIFF
--- a/server/audio/audio_pipewire.cpp
+++ b/server/audio/audio_pipewire.cpp
@@ -128,8 +128,8 @@ struct pipewire_device : public audio_device
 			                "Audio/Sink",
 			                PW_KEY_MEDIA_ROLE,
 			                "Game",
-							PW_KEY_NODE_VIRTUAL,
-							"true",
+			                PW_KEY_NODE_VIRTUAL,
+			                "true",
 			                // Set stream rate to match client, preventing PipeWire from doing
 			                // unnecessary resampling which degrades audio quality
 			                PW_KEY_NODE_RATE,
@@ -173,8 +173,8 @@ struct pipewire_device : public audio_device
 		if (info.microphone)
 		{
 			desc.microphone = {
-					.num_channels = info.microphone->num_channels,
-					.sample_rate = info.microphone->sample_rate,
+			        .num_channels = info.microphone->num_channels,
+			        .sample_rate = info.microphone->sample_rate,
 			};
 
 			// Calculate quantum size: 5ms buffer for low latency while maintaining stability
@@ -186,36 +186,36 @@ struct pipewire_device : public audio_device
 			std::string latency_str = std::format("{}/{}", quantum_size, desc.microphone->sample_rate);
 
 			microphone.reset(pw_stream_new_simple(
-					pw_main_loop_get_loop(pw_loop.get()),
-					source_name.c_str(),
-					pw_properties_new(
-							PW_KEY_NODE_NAME,
-							source_name.c_str(),
-							PW_KEY_NODE_DESCRIPTION,
-							source_description.c_str(),
-							PW_KEY_MEDIA_TYPE,
-							"Audio",
-							PW_KEY_MEDIA_CATEGORY,
-							"Playback",
-							PW_KEY_MEDIA_CLASS,
-							"Audio/Source",
-							PW_KEY_MEDIA_ROLE,
-							"Game",
-							PW_KEY_NODE_VIRTUAL,
-							"true",
-							// Set stream rate to match client, preventing PipeWire from doing
-							// unnecessary resampling which degrades audio quality
-							PW_KEY_NODE_RATE,
-							rate_str.c_str(),
-							// Declare target latency to help PipeWire optimize buffering
-							PW_KEY_NODE_LATENCY,
-							latency_str.c_str(),
-							// Force constant quantum size to prevent dynamic buffer size changes
-							PW_KEY_NODE_FORCE_QUANTUM,
+			        pw_main_loop_get_loop(pw_loop.get()),
+			        source_name.c_str(),
+			        pw_properties_new(
+			                PW_KEY_NODE_NAME,
+			                source_name.c_str(),
+			                PW_KEY_NODE_DESCRIPTION,
+			                source_description.c_str(),
+			                PW_KEY_MEDIA_TYPE,
+			                "Audio",
+			                PW_KEY_MEDIA_CATEGORY,
+			                "Playback",
+			                PW_KEY_MEDIA_CLASS,
+			                "Audio/Source",
+			                PW_KEY_MEDIA_ROLE,
+			                "Game",
+			                PW_KEY_NODE_VIRTUAL,
+			                "true",
+			                // Set stream rate to match client, preventing PipeWire from doing
+			                // unnecessary resampling which degrades audio quality
+			                PW_KEY_NODE_RATE,
+			                rate_str.c_str(),
+			                // Declare target latency to help PipeWire optimize buffering
+			                PW_KEY_NODE_LATENCY,
 			                latency_str.c_str(),
-							NULL),
-					&mic_events,
-					this));
+			                // Force constant quantum size to prevent dynamic buffer size changes
+			                PW_KEY_NODE_FORCE_QUANTUM,
+			                latency_str.c_str(),
+			                NULL),
+			        &mic_events,
+			        this));
 			std::vector<uint8_t> buffer(1024);
 			spa_pod_builder b = SPA_POD_BUILDER_INIT(buffer.data(), uint32_t(buffer.size()));
 


### PR DESCRIPTION
This pr was made as a fix to yesterday's one #716 since it wasn't able to be set as the default device to play audio to. This was caused by missing the `c_str()` method when setting the pipewire sink parameters which would make it not be selectable since the configuration would point to a destroyed memory address and not be the correct string for the format. This hopefully addresses all the issues in both cases. 