### PR TITLE
fix(dashboard): add missing includes

### DIFF
--- a/dashboard/settings.cpp
+++ b/dashboard/settings.cpp
@@ -28,6 +28,7 @@
 #include <fcntl.h>
 #include <nlohmann/json.hpp>
 #include <qqmlintegration.h>
+#include <unistd.h>
 
 namespace
 {


### PR DESCRIPTION
The close() function requires <unistd.h> to be included. This was not caught on older toolchains which transitively included it through other headers, but newer GCC/glibc requires explicit includes.