### PR TITLE
foveated encoding slider steps to 5

### DIFF
--- a/client/scenes/lobby_gui.cpp
+++ b/client/scenes/lobby_gui.cpp
@@ -673,7 +673,7 @@ void scenes::lobby::gui_settings()
 
 	// foveation
 	{
-		const int step = 10;
+		const int step = 5;
 		const auto current = config.get_stream_scale();
 		int intval = round((1 - current) * 100 / step);
 		const auto slider = ImGui::SliderInt(


### PR DESCRIPTION
Especially at higher values, the difference can be too great with a step value of 10.

Consider these points, with eye tracking in mind:
- The value of 70 is what most people I believe would consider a high-quality option. The sweet spot is large and there is little to no aliasing in the periphery.
- The value of 60 I find to be overkill with eye-tracking. I think 65 would satisfy the small amount of people who find the aliasing of 70 to be distracting.
- With a value of 80, there is very strong aliasing in the periphery. I would imagine that 80 would only be popular for competitive play of rhythm games or other latency-optimized scenarios, where the user intentionally wants to sacrifice on this front.
- The value of 75 has noticeable aliasing, but I think it's still a good middle-ground to have between 70 and 80. Especially in 3D environments where the aliasing is less visible (when compared to overlays with text).

The slider itself is really long and even with a step value of 5 the user will not have issues selecting their desired value.