### PR TITLE
fix(encoder_settings): fix FTBFS when only WIVRN_USE_VULKAN

### DIFF
--- a/server/encoder/encoder_settings.cpp
+++ b/server/encoder/encoder_settings.cpp
@@ -351,6 +351,7 @@ std::array<encoder_settings, 3> get_encoder_settings(wivrn_vk_bundle & bundle, c
 		}
 	};
 
+#if WIVRN_USE_VAAPI
 	auto check_vaapi = [&](int bit_depth) {
 		for (const auto & encoder: res)
 		{
@@ -379,6 +380,11 @@ std::array<encoder_settings, 3> get_encoder_settings(wivrn_vk_bundle & bundle, c
 		}
 		return true;
 	};
+#else
+	auto check_vaapi = [&](int) {
+		return true;
+	};
+#endif
 
 	if (bit_depth == 10 and not(check_format(vk::Format::eR16Unorm) and check_vaapi(*bit_depth)))
 	{


### PR DESCRIPTION
Fix failure to build with the following settings:

```
WINVRN_USE_VAAPI=OFF
WINVRN_USE_X264=OFF
WINVRN_USE_NVENC=OFF
WINVRN_USE_VULKAN=ON
```