### PR TITLE
fix(polynominal-interpolator): FTBFS on ppc64le

### DIFF
--- a/server/driver/polynomial_interpolator.h
+++ b/server/driver/polynomial_interpolator.h
@@ -23,6 +23,9 @@
 #ifdef Success
 #undef Success
 #endif
+#ifdef Complex
+#undef Complex
+#endif
 
 #include <Eigen/Cholesky>
 #include <Eigen/Core>


### PR DESCRIPTION
X11's Xlib.h does #define Complex 0. On ppc64le, Eigen's AltiVec code (MatrixProductCommon.h, MatrixProduct.h) uses Complex as a template parameter name. When the macro is active, bool Complex becomes bool 0, causing a parse error. This only affects POWER architectures because the AltiVec matrix product code paths are conditionally compiled.                             
                                                                                                        
`Complex` is just another one like `Success` from Xlib fun that wasn't encountered until building on ppc64le. 