### PR TITLE
Enable intra refresh for NVENC

### DIFF
--- a/server/encoder/video_encoder_nvenc.cpp
+++ b/server/encoder/video_encoder_nvenc.cpp
@@ -232,6 +232,9 @@ video_encoder_nvenc::video_encoder_nvenc(
 			config.encodeCodecConfig.h264Config.maxNumRefFrames = 0;
 			config.encodeCodecConfig.h264Config.idrPeriod = NVENC_INFINITE_GOPLENGTH;
 			config.encodeCodecConfig.h264Config.h264VUIParameters.videoFullRangeFlag = 1;
+			config.encodeCodecConfig.h264Config.enableIntraRefresh = 1;
+			config.encodeCodecConfig.h264Config.intraRefreshPeriod = (uint32_t)fps;
+			config.encodeCodecConfig.h264Config.intraRefreshCnt = (uint32_t)(fps / 2);
 
 			break;
 		case video_codec::h265:
@@ -248,6 +251,9 @@ video_encoder_nvenc::video_encoder_nvenc(
 			config.encodeCodecConfig.hevcConfig.maxNumRefFramesInDPB = 0;
 			config.encodeCodecConfig.hevcConfig.idrPeriod = NVENC_INFINITE_GOPLENGTH;
 			config.encodeCodecConfig.hevcConfig.hevcVUIParameters.videoFullRangeFlag = 1;
+			config.encodeCodecConfig.hevcConfig.enableIntraRefresh = 1;
+			config.encodeCodecConfig.hevcConfig.intraRefreshPeriod = (uint32_t)fps;
+			config.encodeCodecConfig.hevcConfig.intraRefreshCnt = (uint32_t)(fps / 2);
 
 			break;
 		case video_codec::av1:
@@ -263,6 +269,9 @@ video_encoder_nvenc::video_encoder_nvenc(
 			config.encodeCodecConfig.av1Config.repeatSeqHdr = 1;
 			config.encodeCodecConfig.av1Config.maxNumRefFramesInDPB = 0;
 			config.encodeCodecConfig.av1Config.idrPeriod = NVENC_INFINITE_GOPLENGTH;
+			config.encodeCodecConfig.av1Config.enableIntraRefresh = 1;
+			config.encodeCodecConfig.av1Config.intraRefreshPeriod = (uint32_t)fps;
+			config.encodeCodecConfig.av1Config.intraRefreshCnt = (uint32_t)(fps / 2);
 
 			break;
 		case video_codec::raw:

--- a/server/encoder/video_encoder_nvenc.cpp
+++ b/server/encoder/video_encoder_nvenc.cpp
@@ -221,6 +221,14 @@ video_encoder_nvenc::video_encoder_nvenc(
 			throw std::runtime_error("nvenc: 10-bit encoding requested, but GPU doesn't support it");
 		}
 	}
+	const uint32_t intra_refresh_period = 100;
+	const uint32_t intra_refresh_cnt = 50;
+	auto set_intra_refresh = [&](auto & codec_config) {
+		codec_config.idrPeriod = NVENC_INFINITE_GOPLENGTH;
+		codec_config.enableIntraRefresh = 1;
+		codec_config.intraRefreshPeriod = intra_refresh_period;
+		codec_config.intraRefreshCnt = intra_refresh_cnt;
+	};
 
 	switch (settings.codec)
 	{
@@ -230,11 +238,8 @@ video_encoder_nvenc::video_encoder_nvenc(
 
 			config.encodeCodecConfig.h264Config.repeatSPSPPS = 1;
 			config.encodeCodecConfig.h264Config.maxNumRefFrames = 0;
-			config.encodeCodecConfig.h264Config.idrPeriod = NVENC_INFINITE_GOPLENGTH;
 			config.encodeCodecConfig.h264Config.h264VUIParameters.videoFullRangeFlag = 1;
-			config.encodeCodecConfig.h264Config.enableIntraRefresh = 1;
-			config.encodeCodecConfig.h264Config.intraRefreshPeriod = (uint32_t)fps;
-			config.encodeCodecConfig.h264Config.intraRefreshCnt = (uint32_t)(fps / 2);
+			set_intra_refresh(config.encodeCodecConfig.h264Config);
 
 			break;
 		case video_codec::h265:
@@ -249,11 +254,8 @@ video_encoder_nvenc::video_encoder_nvenc(
 
 			config.encodeCodecConfig.hevcConfig.repeatSPSPPS = 1;
 			config.encodeCodecConfig.hevcConfig.maxNumRefFramesInDPB = 0;
-			config.encodeCodecConfig.hevcConfig.idrPeriod = NVENC_INFINITE_GOPLENGTH;
 			config.encodeCodecConfig.hevcConfig.hevcVUIParameters.videoFullRangeFlag = 1;
-			config.encodeCodecConfig.hevcConfig.enableIntraRefresh = 1;
-			config.encodeCodecConfig.hevcConfig.intraRefreshPeriod = (uint32_t)fps;
-			config.encodeCodecConfig.hevcConfig.intraRefreshCnt = (uint32_t)(fps / 2);
+			set_intra_refresh(config.encodeCodecConfig.hevcConfig);
 
 			break;
 		case video_codec::av1:
@@ -268,10 +270,7 @@ video_encoder_nvenc::video_encoder_nvenc(
 
 			config.encodeCodecConfig.av1Config.repeatSeqHdr = 1;
 			config.encodeCodecConfig.av1Config.maxNumRefFramesInDPB = 0;
-			config.encodeCodecConfig.av1Config.idrPeriod = NVENC_INFINITE_GOPLENGTH;
-			config.encodeCodecConfig.av1Config.enableIntraRefresh = 1;
-			config.encodeCodecConfig.av1Config.intraRefreshPeriod = (uint32_t)fps;
-			config.encodeCodecConfig.av1Config.intraRefreshCnt = (uint32_t)(fps / 2);
+			set_intra_refresh(config.encodeCodecConfig.av1Config);
 
 			break;
 		case video_codec::raw:


### PR DESCRIPTION
This can solve the severe artifacts that occur during long-term streaming. Compared to implementing image quality detection on the client side, this solution is simpler.