### PR TITLE
client: sync display and stream refresh rate after wake up

### DIFF
--- a/client/scenes/stream.cpp
+++ b/client/scenes/stream.cpp
@@ -1319,6 +1319,10 @@ void scenes::stream::on_xr_event(const xr::event & event)
 			});
 			break;
 		case XR_TYPE_EVENT_DATA_SESSION_STATE_CHANGED:
+			// sync display refresh rate with video stream when regaining focus
+			if (event.state_changed.state == XR_SESSION_STATE_READY and video_stream_description)
+				session.set_refresh_rate(video_stream_description->fps);
+
 			// Override session state if the GUI is interactable
 			if (event.state_changed.state == XR_SESSION_STATE_FOCUSED and is_gui_interactable())
 				network_session->send_control(from_headset::session_state_changed{


### PR DESCRIPTION
This is a quick patch for resetting refresh rate on meta headsets, which set their refresh rate to 72 when waking up.

Though ideally wivrn should be also able to return to the user specified refresh rate in general when the runtime changes it (perhaps after a small delay?), fixing #741 in return.