### PR TITLE
Add wivrn-version dependency to common-base

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(wivrn-common-base STATIC EXCLUDE_FROM_ALL
     utils/xdg_base_directory.cpp
     ${CMAKE_BINARY_DIR}/version.cpp
 )
+add_dependencies(wivrn-common-base wivrn-version)
 
 add_library(wivrn-common STATIC EXCLUDE_FROM_ALL
     crypto.cpp


### PR DESCRIPTION
This causes the packaging in nixpkgs-xr to fail. Not sure why other builds aren't affected.

See https://github.com/nix-community/nixpkgs-xr/pull/669

https://buildbot.nix-community.org/#/builders/4015/builds/442/steps/1/logs/stdio
