### PR TITLE
Add . button to number keyboard

### DIFF
--- a/client/scenes/lobby_keyboard.cpp
+++ b/client/scenes/lobby_keyboard.cpp
@@ -199,7 +199,7 @@ virtual_keyboard::layout symbols = {
         }, // 12
         {
                 {1.5},
-                {1}, // {1, "", ImGuiKey_None, "1/2", virtual_keyboard::key_flag_hidden},
+                {1, "."},
                 {1, "\""},
                 {1, "<"},
                 {1, ">"},


### PR DESCRIPTION
Add . button to number keyboard.
This is to fix an minor ux problem when when typing ip addresses you had to switch between the numbers and letters keyboard layout which would get annoying