### PR TITLE
server: wait for headset before sending frames

### DIFF
--- a/server/compositor/compositor.cpp
+++ b/server/compositor/compositor.cpp
@@ -266,7 +266,7 @@ xrt_result_t compositor::layer_commit(xrt_graphics_sync_handle_t sync_handle)
 	auto _ = vk.device.waitForFences(*fence, true, INT64_MAX);
 
 	if (encode_request >= 0 // encoders have not picked up the previous frame
-	    or layer_accum.layer_count == 0 or not session.connected())
+	    or layer_accum.layer_count == 0 or not session.connected() or not session.get_offset())
 	{
 		comp_frame_clear_locked(&frame.rendering);
 		return XRT_SUCCESS;


### PR DESCRIPTION
Make sure we have a valid clock offset (and therefore view poses) before starting to encode frames.

This is really only visible when reconnecting, where the server is able to start streaming immediately before tracking had a chance to react.