### PR TITLE
Fix null pointer dereference in start_application

### DIFF
--- a/server/start_application.cpp
+++ b/server/start_application.cpp
@@ -152,10 +152,10 @@ void forked_children::start_application(const std::vector<std::string> & args, c
 	{
 		tmp.push_back("flatpak-spawn");
 		tmp.push_back("--host");
-		if (path)
+		if (path.has_value())
 			tmp.push_back("--directory=" + *path);
 	}
-	else
+	else if (path.has_value())
 	{
 		try
 		{

--- a/server/start_application.cpp
+++ b/server/start_application.cpp
@@ -152,10 +152,10 @@ void forked_children::start_application(const std::vector<std::string> & args, c
 	{
 		tmp.push_back("flatpak-spawn");
 		tmp.push_back("--host");
-		if (path.has_value())
+		if (path)
 			tmp.push_back("--directory=" + *path);
 	}
-	else if (path.has_value())
+	else if (path)
 	{
 		try
 		{


### PR DESCRIPTION
Fixes SIGABRT on my machine
```
[2026-04-17T00:31:49.177] /usr/include/c++/15.2.1/optional:1179: constexpr const _Tp& std::optional<_Tp>::operator*() const & [with _Tp = std::__cxx11::basic_string<char>]: Assertion 'this->_M_is_engaged()' failed.
[2026-04-17T00:31:49.895] Application exited, exit status 0, received signal ABRT (Aborted), core dumped
[2026-04-17T00:32:01.566] /usr/include/c++/15.2.1/optional:1179: constexpr const _Tp& std::optional<_Tp>::operator*() const & [with _Tp = std::__cxx11::basic_string<char>]: Assertion 'this->_M_is_engaged()' failed.
[2026-04-17T00:32:01.819] Application exited, exit status 0, received signal ABRT (Aborted), core dumped
```