### PR TITLE
Compositor: defer GPU wait/query/GC to encoder thread

### DIFF
--- a/server/compositor/compositor.cpp
+++ b/server/compositor/compositor.cpp
@@ -323,8 +323,8 @@ xrt_result_t compositor::layer_commit(xrt_graphics_sync_handle_t sync_handle)
 	cmd_pool.reset();
 	cmd.begin({.flags = vk::CommandBufferUsageFlagBits::eOneTimeSubmit});
 
-	cmd.resetQueryPool(*query_pool, 0, 3);
-	cmd.writeTimestamp(vk::PipelineStageFlagBits::eTopOfPipe, *query_pool, 0);
+	cmd.resetQueryPool(*query_pool, i * 3, 3);
+	cmd.writeTimestamp(vk::PipelineStageFlagBits::eTopOfPipe, *query_pool, i * 3 + 0);
 
 	bool flip_y = false;
 	std::array<vk::ImageView, 2> src;
@@ -412,7 +412,7 @@ xrt_result_t compositor::layer_commit(xrt_graphics_sync_handle_t sync_handle)
 	});
 	image_barriers.clear();
 
-	cmd.writeTimestamp(vk::PipelineStageFlagBits::eBottomOfPipe, *query_pool, 1);
+	cmd.writeTimestamp(vk::PipelineStageFlagBits::eBottomOfPipe, *query_pool, i * 3 + 1);
 
 	if (session.get_info().eye_gaze)
 	{
@@ -458,7 +458,7 @@ xrt_result_t compositor::layer_commit(xrt_graphics_sync_handle_t sync_handle)
 	        .imageMemoryBarrierCount = uint32_t(image_barriers.size()),
 	        .pImageMemoryBarriers = image_barriers.data(),
 	});
-	cmd.writeTimestamp(vk::PipelineStageFlagBits::eBottomOfPipe, *query_pool, 2);
+	cmd.writeTimestamp(vk::PipelineStageFlagBits::eBottomOfPipe, *query_pool, i * 3 + 2);
 
 	cmd.end();
 
@@ -481,6 +481,10 @@ xrt_result_t compositor::layer_commit(xrt_graphics_sync_handle_t sync_handle)
 		});
 	}
 
+	pacer.mark_timing_point(COMP_TARGET_TIMING_POINT_SUBMIT_END,
+	                        frame.rendering.id,
+	                        os_monotonic_get_ns());
+
 	auto info = pacer.present_to_info(frame.rendering.desired_present_time_ns);
 
 	for (auto & encoder: encoders)
@@ -493,6 +497,8 @@ xrt_result_t compositor::layer_commit(xrt_graphics_sync_handle_t sync_handle)
 		        info.frame_id);
 	}
 
+	images[i].sem_value = sem_info.value;
+
 	auto j = encode_request.exchange(i);
 	encode_request.notify_all();
 	assert(j == -1);
@@ -503,35 +509,6 @@ xrt_result_t compositor::layer_commit(xrt_graphics_sync_handle_t sync_handle)
 #endif
 
 	comp_frame_clear_locked(&frame.rendering);
-
-	if (vk.device.waitSemaphores(vk::SemaphoreWaitInfo{
-	                                     .semaphoreCount = 1,
-	                                     .pSemaphores = &*sem,
-	                                     .pValues = &sem_info.value,
-	                             },
-	                             U_TIME_1S_IN_NS) == vk::Result::eTimeout)
-	{
-		U_LOG_IFL_W(log_level, "compositor timeout");
-	}
-	else
-	{
-		auto [res, ts] = query_pool.getResults<uint64_t>(
-		        0,
-		        3,
-		        3 * sizeof(uint64_t),
-		        sizeof(uint64_t),
-		        vk::QueryResultFlagBits::e64 | vk::QueryResultFlagBits::eWait);
-
-		if (res == vk::Result::eSuccess)
-		{
-			static const auto period = vk.physical_device.getProperties().limits.timestampPeriod;
-			squasher_times.add((ts[1] - ts[0]) * period / 1e3);
-			foveation_times.add((ts[2] - ts[1]) * period / 1e3);
-		}
-	}
-
-	// Now is a good point to garbage collect.
-	comp_swapchain_shared_garbage_collect(&cscs);
 
 	return XRT_SUCCESS;
 }
@@ -631,6 +608,36 @@ void compositor::encoder_work(std::stop_token tok)
 		{
 			U_LOG_W("encode error: %s", e.what());
 		}
+
+		if (vk.device.waitSemaphores(vk::SemaphoreWaitInfo{
+		                                     .semaphoreCount = 1,
+		                                     .pSemaphores = &*sem,
+		                                     .pValues = &image.sem_value,
+		                             },
+		                             U_TIME_1S_IN_NS) == vk::Result::eTimeout)
+		{
+			U_LOG_IFL_W(log_level, "compositor timeout");
+		}
+		else
+		{
+			auto [res, ts] = query_pool.getResults<uint64_t>(
+			        req * 3,
+			        3,
+			        3 * sizeof(uint64_t),
+			        sizeof(uint64_t),
+			        vk::QueryResultFlagBits::e64);
+
+			if (res == vk::Result::eSuccess)
+			{
+				static const auto period = vk.physical_device.getProperties().limits.timestampPeriod;
+				squasher_times.add((ts[1] - ts[0]) * period / 1e3);
+				foveation_times.add((ts[2] - ts[1]) * period / 1e3);
+			}
+		}
+
+		// Now is a good point to garbage collect.
+		comp_swapchain_shared_garbage_collect(&cscs);
+
 		image.busy = false;
 	}
 }
@@ -675,7 +682,7 @@ compositor::compositor(wivrn_session & session) :
                             }),
         query_pool(vk.device, vk::QueryPoolCreateInfo{
                                       .queryType = vk::QueryType::eTimestamp,
-                                      .queryCount = 3,
+                                      .queryCount = 6,
                               }),
         settings(get_encoder_settings(vk, session)),
         images{make_images(vk, cmd_pool, settings)},

--- a/server/compositor/compositor.h
+++ b/server/compositor/compositor.h
@@ -54,6 +54,7 @@ public:
 		vk::raii::ImageView view_cbcr;
 		to_headset::video_stream_data_shard::view_info_t view_info{};
 		uint64_t frame_index;
+		uint64_t sem_value;
 	};
 
 private:


### PR DESCRIPTION
This PR addresses two major performance regressions introduced in the 22a819b8 architecture.
---
Previously, `compositor::layer_commit` performed synchronous waits on the Vulkan timeline semaphore and ran swapchain garbage collection while on Monado’s `multi_main_loop` system thread. 
- Issue: This created a **3–5 ms stall** per layer commit, preventing the `comp_multi` scheduled slot from draining. This resulted in "Frame late" and "GPU work waiting to be displayed" warnings.
- Fix: Moved these blocking operations to the **encoder thread**. `layer_commit` now returns immediately after publishing the encode request, restoring microsecond-level latency to the system thread.
---
The rewritten architecture stopped feeding `SUBMIT_END` timestamps to `pacer::mark_timing_point`.
- Issue:*Without feedback, `mean_wake_up_to_present_ns` remained stuck at its 1ms default. This caused `predict_frame` to calculate inaccurate wake-up times, consistently waking the application too late.
- Fix: Re-implemented the timing feedback path, allowing the pacer to converge on the real GPU latency and ensuring accurate application wake-up predictions.
---
- Indexed Query Pool: Expanded the query pool and implemented per-image slot indexing (offset `i * 3`) to prevent frame N+1 from overwriting frame N’s timestamps during asynchronous processing.
- Deferred Wait: In-flight images now carry a `sem_value` so the encoder thread can wait on the specific timeline value before recycling the image.