### PR TITLE
Add runtime-initialized 'hmd_traits' struct to streamline hmd-specific behavior checks

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - preset: 'client'
-            packages: libboost-all-dev libharfbuzz-dev libfreetype-dev libavcodec-dev libavutil-dev libswscale-dev librsvg2-bin gettext libcurl4-openssl-dev libfontconfig-dev
+          - preset: 'client-no-system-boost'
+            packages: libharfbuzz-dev libfreetype-dev libavcodec-dev libavutil-dev libswscale-dev librsvg2-bin gettext libcurl4-openssl-dev libfontconfig-dev
         # dashboard requires a more recent Ubuntu, have it out of this job
           - preset: 'dissector-no-system-boost'
             packages: libboost-all-dev wireshark-dev
@@ -57,7 +57,7 @@ jobs:
         restore-keys: cmake-linux-
 
     - name: Install dependencies
-      if: ${{ matrix.config.preset == 'client' }}
+      if: ${{ startswith(matrix.config.preset, 'client') }}
       run: |
         wget https://github.com/KhronosGroup/KTX-Software/releases/download/v4.4.2/KTX-Software-4.4.2-Linux-x86_64.deb
         sudo dpkg --install KTX-Software-4.4.2-Linux-x86_64.deb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ endif()
 include(VulkanVersion)
 
 if (WIVRN_USE_SYSTEM_BOOST AND NEED_COMMON)
-    if (WIVRN_BUILD_DISSECTOR)
+    if (WIVRN_BUILD_DISSECTOR OR WIVRN_BUILD_CLIENT)
         find_package(Boost 1.84.0 REQUIRED COMPONENTS locale url iostreams)
     else()
         find_package(Boost 1.75.0 REQUIRED COMPONENTS locale url iostreams)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -114,6 +114,15 @@
 			}
 		},
 		{
+			"name": "client-no-system-boost",
+			"displayName": "Client only (no system Boost)",
+			"inherits": "client",
+			"binaryDir": "${sourceDir}/build-client-no-system-boost",
+			"cacheVariables": {
+				"WIVRN_USE_SYSTEM_BOOST": "OFF"
+			}
+		},
+		{
 			"name": "server-no-system-boost",
 			"displayName": "Server only (no system Boost)",
 			"inherits": "server",

--- a/client/application.cpp
+++ b/client/application.cpp
@@ -749,8 +749,7 @@ void application::initialize_vulkan()
 			instance_extensions.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
 		}
 
-		if (!strcmp(i.extensionName, VK_EXT_DEBUG_UTILS_EXTENSION_NAME) and
-		    guess_model() != model::oculus_quest) // Quest 1 lies, the extension won't load
+		if (!strcmp(i.extensionName, VK_EXT_DEBUG_UTILS_EXTENSION_NAME) and hmd_traits.vk_debug_ext_allowed)
 		{
 			debug_utils_found = true;
 			instance_extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
@@ -1006,21 +1005,8 @@ void application::initialize_actions()
 		profile.available = std::ranges::all_of(profile.required_extensions, [&](auto & ext) { return xr_instance.has_extension(ext); }) and
 		                    profile.min_version <= api_version;
 
-		if (profile.profile_name.ends_with("khr/simple_controller"))
-		{
-			switch (guess_model())
-			{
-				// Quest hand tracking creates a fake khr/simple_controller when hand tracking
-				// is enabled, this messes with native hand tracking
-				case model::meta_quest_3:
-				case model::meta_quest_pro:
-				case model::meta_quest_3s:
-				case model::oculus_quest_2:
-					profile.available = false;
-				default:
-					break;
-			}
-		}
+		if (profile.profile_name.ends_with("khr/simple_controller") and not hmd_traits.bind_simple_controller)
+			profile.available = false;
 
 		if (!profile.available)
 			continue;
@@ -1028,21 +1014,8 @@ void application::initialize_actions()
 		// Patch profile to add grip_surface or palm_ext
 		bool add_palms = true;
 		if (profile.profile_name.ends_with("ext/hand_interaction_ext"))
-		{
-			switch (guess_model())
-			{
-				// Quest breaks spec and does not support grip_surface for ext/hand_interaction_ext
-				case model::meta_quest_3:
-				case model::meta_quest_pro:
-				case model::meta_quest_3s:
-				case model::oculus_quest_2:
-				case model::oculus_quest:
-					add_palms = false;
-					break;
-				default:
-					break;
-			}
-		}
+			add_palms = hmd_traits.hand_interaction_grip_surface;
+
 		if (add_palms)
 		{
 			if ((api_version >= XR_MAKE_VERSION(1, 1, 0) or xr_instance.has_extension(XR_KHR_MAINTENANCE1_EXTENSION_NAME)) //
@@ -1465,7 +1438,6 @@ application::application(application_info info) :
         app_info(std::move(info))
 
 {
-	initialize_runtime_hmd_traits();
 #ifdef __ANDROID__
 	// https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/types.html
 

--- a/client/application.cpp
+++ b/client/application.cpp
@@ -19,7 +19,6 @@
 
 #include "application.h"
 
-#include "hardware.h"
 #include "openxr/openxr.h"
 #include "scene.h"
 #include "spdlog/common.h"
@@ -749,7 +748,7 @@ void application::initialize_vulkan()
 			instance_extensions.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
 		}
 
-		if (!strcmp(i.extensionName, VK_EXT_DEBUG_UTILS_EXTENSION_NAME) and hmd_traits().vk_debug_ext_allowed)
+		if (!strcmp(i.extensionName, VK_EXT_DEBUG_UTILS_EXTENSION_NAME) and get_hmd_traits().vk_debug_ext_allowed)
 		{
 			debug_utils_found = true;
 			instance_extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
@@ -1005,7 +1004,7 @@ void application::initialize_actions()
 		profile.available = std::ranges::all_of(profile.required_extensions, [&](auto & ext) { return xr_instance.has_extension(ext); }) and
 		                    profile.min_version <= api_version;
 
-		if (profile.profile_name.ends_with("khr/simple_controller") and not hmd_traits().bind_simple_controller)
+		if (profile.profile_name.ends_with("khr/simple_controller") and not get_hmd_traits().bind_simple_controller)
 			profile.available = false;
 
 		if (!profile.available)
@@ -1014,7 +1013,7 @@ void application::initialize_actions()
 		// Patch profile to add grip_surface or palm_ext
 		bool add_palms = true;
 		if (profile.profile_name.ends_with("ext/hand_interaction_ext"))
-			add_palms = hmd_traits().hand_interaction_grip_surface;
+			add_palms = get_hmd_traits().hand_interaction_grip_surface;
 
 		if (add_palms)
 		{
@@ -1185,7 +1184,7 @@ void application::initialize_actions()
 
 void application::initialize()
 {
-	hmd_traits_init();
+	runtime_hmd_traits.init();
 	// LogLayersAndExtensions
 	assert(!xr_instance);
 	std::vector<const char *> xr_extensions{

--- a/client/application.cpp
+++ b/client/application.cpp
@@ -749,7 +749,7 @@ void application::initialize_vulkan()
 			instance_extensions.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
 		}
 
-		if (!strcmp(i.extensionName, VK_EXT_DEBUG_UTILS_EXTENSION_NAME) and hmd_traits.vk_debug_ext_allowed)
+		if (!strcmp(i.extensionName, VK_EXT_DEBUG_UTILS_EXTENSION_NAME) and hmd_traits().vk_debug_ext_allowed)
 		{
 			debug_utils_found = true;
 			instance_extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
@@ -1005,7 +1005,7 @@ void application::initialize_actions()
 		profile.available = std::ranges::all_of(profile.required_extensions, [&](auto & ext) { return xr_instance.has_extension(ext); }) and
 		                    profile.min_version <= api_version;
 
-		if (profile.profile_name.ends_with("khr/simple_controller") and not hmd_traits.bind_simple_controller)
+		if (profile.profile_name.ends_with("khr/simple_controller") and not hmd_traits().bind_simple_controller)
 			profile.available = false;
 
 		if (!profile.available)
@@ -1014,7 +1014,7 @@ void application::initialize_actions()
 		// Patch profile to add grip_surface or palm_ext
 		bool add_palms = true;
 		if (profile.profile_name.ends_with("ext/hand_interaction_ext"))
-			add_palms = hmd_traits.hand_interaction_grip_surface;
+			add_palms = hmd_traits().hand_interaction_grip_surface;
 
 		if (add_palms)
 		{
@@ -1185,6 +1185,7 @@ void application::initialize_actions()
 
 void application::initialize()
 {
+	hmd_traits_init();
 	// LogLayersAndExtensions
 	assert(!xr_instance);
 	std::vector<const char *> xr_extensions{

--- a/client/application.cpp
+++ b/client/application.cpp
@@ -1465,6 +1465,7 @@ application::application(application_info info) :
         app_info(std::move(info))
 
 {
+	initialize_runtime_hmd_traits();
 #ifdef __ANDROID__
 	// https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/types.html
 

--- a/client/application.h
+++ b/client/application.h
@@ -25,6 +25,7 @@
 #endif
 
 #include "configuration.h"
+#include "hmd_traits.h"
 #include "utils/singleton.h"
 #include "utils/thread_safe.h"
 #include "vk/vk_allocator.h"
@@ -74,6 +75,7 @@ class application : public singleton<application>
 {
 	friend class scene;
 
+private:
 #ifdef __ANDROID__
 	friend __attribute__((visibility("default"))) void Java_org_meumeu_wivrn_MainActivity_onNewIntent(JNIEnv * env, jobject instance, jobject intent_obj);
 #endif
@@ -157,6 +159,7 @@ class application : public singleton<application>
 
 	boost::locale::generator gen;
 	boost::locale::gnu_gettext::messages_info messages_info;
+	hmd_traits runtime_hmd_traits;
 
 private:
 	void loop();
@@ -400,6 +403,12 @@ public:
 	static bool get_openxr_post_processing_supported()
 	{
 		return instance().openxr_post_processing_supported;
+	}
+
+	static const hmd_traits & get_hmd_traits()
+	{
+		assert(instance().runtime_hmd_traits.is_initialized());
+		return instance().runtime_hmd_traits;
 	}
 
 	static auto & get_generic_trackers()

--- a/client/configuration.cpp
+++ b/client/configuration.cpp
@@ -70,7 +70,7 @@ bool configuration::check_feature(feature f) const
 		}
 	}
 #ifdef __ANDROID__
-	return check_permission(permission_name_for_hmd(runtime_hmd_traits(), f));
+	return check_permission(hmd_traits.permissions[f]);
 #else
 	return true;
 #endif
@@ -81,7 +81,7 @@ void configuration::set_feature(feature f, bool state)
 #ifdef __ANDROID__
 	if (state)
 	{
-		request_permission(permission_name_for_hmd(runtime_hmd_traits(), f), [this, f](bool granted) {
+		request_permission(hmd_traits.permissions[f], [this, f](bool granted) {
 			{
 				std::lock_guard lock(mutex);
 				features[f] = granted;
@@ -103,29 +103,6 @@ configuration::configuration(xr::system & system, xr::session & session)
 {
 	passthrough_enabled = system.passthrough_supported() == xr::passthrough_type::color;
 	features[feature::hand_tracking] = system.hand_tracking_supported();
-	switch (guess_model())
-	{
-		case model::oculus_quest:
-		case model::oculus_quest_2:
-		case model::meta_quest_pro:
-		case model::meta_quest_3:
-		case model::meta_quest_3s:
-			high_power_mode = false;
-			break;
-		case model::pico_neo_3:
-		case model::pico_4:
-		case model::pico_4s:
-		case model::pico_4_pro:
-		case model::pico_4_enterprise:
-		case model::htc_vive_focus_3:
-		case model::htc_vive_xr_elite:
-		case model::htc_vive_focus_vision:
-		case model::lynx_r1:
-		case model::samsung_galaxy_xr:
-		case model::unknown:
-			high_power_mode = true;
-			break;
-	}
 
 	const auto & rates = session.get_refresh_rates();
 	for (auto rate: rates)

--- a/client/configuration.cpp
+++ b/client/configuration.cpp
@@ -70,7 +70,7 @@ bool configuration::check_feature(feature f) const
 		}
 	}
 #ifdef __ANDROID__
-	return check_permission(hmd_traits().permissions[f]);
+	return check_permission(application::get_hmd_traits().permission_name(f));
 #else
 	return true;
 #endif
@@ -81,7 +81,7 @@ void configuration::set_feature(feature f, bool state)
 #ifdef __ANDROID__
 	if (state)
 	{
-		request_permission(hmd_traits().permissions[f], [this, f](bool granted) {
+		request_permission(application::get_hmd_traits().permission_name(f), [this, f](bool granted) {
 			{
 				std::lock_guard lock(mutex);
 				features[f] = granted;

--- a/client/configuration.cpp
+++ b/client/configuration.cpp
@@ -70,7 +70,7 @@ bool configuration::check_feature(feature f) const
 		}
 	}
 #ifdef __ANDROID__
-	return check_permission(permission_name(f));
+	return check_permission(permission_name_for_hmd(runtime_hmd_traits(), f));
 #else
 	return true;
 #endif
@@ -81,7 +81,7 @@ void configuration::set_feature(feature f, bool state)
 #ifdef __ANDROID__
 	if (state)
 	{
-		request_permission(permission_name(f), [this, f](bool granted) {
+		request_permission(permission_name_for_hmd(runtime_hmd_traits(), f), [this, f](bool granted) {
 			{
 				std::lock_guard lock(mutex);
 				features[f] = granted;

--- a/client/configuration.cpp
+++ b/client/configuration.cpp
@@ -70,7 +70,7 @@ bool configuration::check_feature(feature f) const
 		}
 	}
 #ifdef __ANDROID__
-	return check_permission(hmd_traits.permissions[f]);
+	return check_permission(hmd_traits().permissions[f]);
 #else
 	return true;
 #endif
@@ -81,7 +81,7 @@ void configuration::set_feature(feature f, bool state)
 #ifdef __ANDROID__
 	if (state)
 	{
-		request_permission(hmd_traits.permissions[f], [this, f](bool granted) {
+		request_permission(hmd_traits().permissions[f], [this, f](bool granted) {
 			{
 				std::lock_guard lock(mutex);
 				features[f] = granted;

--- a/client/configuration.h
+++ b/client/configuration.h
@@ -80,7 +80,7 @@ public:
 	float override_foveation_pitch = -10 * M_PI / 180;
 	float override_foveation_distance = 3;
 
-	bool high_power_mode;
+	bool high_power_mode = true;
 	uint32_t fps_divider = 1;
 
 	// Allow unsafe config values

--- a/client/configuration.h
+++ b/client/configuration.h
@@ -19,7 +19,6 @@
 
 #pragma once
 
-#include "hardware.h"
 #include "wivrn_discover.h"
 #include "wivrn_packets.h"
 
@@ -28,12 +27,22 @@
 #include <optional>
 #include <simdjson.h>
 #include <string>
+#include <openxr/openxr.h>
 
 namespace xr
 {
 class session;
 class system;
 } // namespace xr
+
+enum class feature
+{
+	microphone,
+	hand_tracking,
+	eye_gaze,
+	face_tracking,
+	body_tracking,
+};
 
 class configuration
 {

--- a/client/hardware.cpp
+++ b/client/hardware.cpp
@@ -25,7 +25,6 @@
 #include <cstring>
 #include <glm/ext/quaternion_trigonometric.hpp>
 #include <limits>
-#include <stdexcept>
 #include <string>
 
 #include <spdlog/spdlog.h>
@@ -35,12 +34,13 @@
 
 #include <sys/system_properties.h>
 
-static std::string get_property(const char * property)
+static std::optional<std::string> get_property(const char * property)
 {
 	auto info = __system_property_find(property);
-	std::string result;
 	if (not info)
-		return result;
+		return std::nullopt;
+
+	std::string result;
 	wrap_lambda cb = [&result](const char * name, const char * value, uint32_t serial) {
 		result = value;
 	};
@@ -50,300 +50,215 @@ static std::string get_property(const char * property)
 }
 #endif
 
-static model guess_model_()
+static std::optional<std::string> env_string(const char * env_name, const char * android_sysprop_name)
 {
+#ifdef __ANDROID__
+	return get_property(android_sysprop_name);
+#else
+	const char * value = std::getenv(env_name);
+	if (value)
+		return value;
+	return std::nullopt;
+#endif
+}
+
+static std::optional<uint32_t> env_u32(const char * env_name, const char * android_sysprop_name)
+{
+	const auto value = env_string(env_name, android_sysprop_name);
+	if (not value)
+		return std::nullopt;
+	try
+	{
+		const unsigned long parsed = std::stoul(*value);
+		if (parsed > std::numeric_limits<uint32_t>::max())
+			return std::nullopt;
+		return static_cast<uint32_t>(parsed);
+	}
+	catch (std::runtime_error & e)
+	{
+		spdlog::warn("failed to parse {} (value: {}: {}",
+#ifdef __ANDROID__
+		             android_sysprop_name,
+#else
+		             env_name,
+#endif
+		             *value,
+		             e.what()
+
+		);
+		return std::nullopt;
+	}
+}
+
+static std::optional<bool> env_bool(const char * env_name, const char * android_sysprop_name)
+{
+	const auto value = env_string(env_name, android_sysprop_name);
+	if (not value)
+		return std::nullopt;
+	if (strcmp(value->c_str(), "1") == 0 || strcasecmp(value->c_str(), "true") == 0 || strcasecmp(value->c_str(), "yes") == 0 || strcasecmp(value->c_str(), "on") == 0)
+		return true;
+	if (strcmp(value->c_str(), "0") == 0 || strcasecmp(value->c_str(), "false") == 0 || strcasecmp(value->c_str(), "no") == 0 || strcasecmp(value->c_str(), "off") == 0)
+		return false;
+	return std::nullopt;
+}
+
+const hmd_traits_t hmd_traits = [] {
+	hmd_traits_t traits{};
+
 #ifdef __ANDROID__
 	const auto device = get_property("ro.product.device");
 	const auto manufacturer = get_property("ro.product.manufacturer");
 	const auto model = get_property("ro.product.model");
 
 	spdlog::info("Guessing HMD model from:");
-	spdlog::info("    ro.product.device = \"{}\":", device);
-	spdlog::info("    ro.product.manufacturer = \"{}\":", manufacturer);
-	spdlog::info("    ro.product.model = \"{}\":", model);
+	spdlog::info("    ro.product.device = \"{}\":", device.value_or("<unset>"));
+	spdlog::info("    ro.product.manufacturer = \"{}\":", manufacturer.value_or("<unset>"));
+	spdlog::info("    ro.product.model = \"{}\":", model.value_or("<unset>"));
 
-	if (device == "monterey")
-		return model::oculus_quest;
-	if (device == "hollywood")
-		return model::oculus_quest_2;
-	if (device == "seacliff")
-		return model::meta_quest_pro;
-	if (device == "eureka")
-		return model::meta_quest_3;
-	if (device == "panther")
-		return model::meta_quest_3s;
-	if (model == "Lynx-R1")
-		return model::lynx_r1;
+	traits.permissions[feature::microphone] = "android.permission.RECORD_AUDIO";
 
-	if (manufacturer == "Pico")
+	if (manufacturer == "Oculus")
 	{
+		traits.permissions[feature::eye_gaze] = "com.oculus.permission.EYE_TRACKING";
+		traits.permissions[feature::face_tracking] = "com.oculus.permission.FACE_TRACKING";
+
+		// Quest hand tracking creates a fake khr/simple_controller when hand tracking
+		// is enabled, this messes with native hand tracking
+		traits.bind_simple_controller = false;
+
+		// Quest breaks spec and does not support grip_surface for ext/hand_interaction_ext
+		traits.hand_interaction_grip_surface = false;
+
+		if (device == "monterey") // Quest 1
+		{
+			traits.panel_width_override = 1440;
+			traits.controller_profile = "oculus-touch-v2";
+			traits.vk_debug_ext_allowed = false; // Quest 1 lies, the extension won't load
+		}
+		else if (device == "hollywood") // Quest 2
+		{
+			traits.panel_width_override = 1832;
+			traits.controller_profile = "oculus-touch-v3";
+		}
+		else if (device == "seacliff")
+		{
+			traits.panel_width_override = 1800; // Quest pro
+			traits.controller_profile = "meta-quest-touch-pro";
+		}
+		else if (device == "eureka")
+		{
+			traits.panel_width_override = 2064; // Quest 3
+			traits.controller_profile = "meta-quest-touch-plus";
+		}
+		else if (device == "panther") // Quest 3S
+		{
+			traits.panel_width_override = 1832;
+			traits.controller_profile = "meta-quest-touch-plus";
+		}
+	}
+
+	else if (model == "Lynx-R1")
+	{
+		traits.needs_srgb_conversion = false;
+	}
+
+	else if (manufacturer == "Pico")
+	{
+		traits.permissions[feature::eye_gaze] = "com.picovr.permission.EYE_TRACKING";
+		traits.permissions[feature::face_tracking] = "com.picovr.permission.FACE_TRACKING";
+		traits.view_locate = false;
 		const auto pico_model = get_property("pxr.vendorhw.product.model");
-		spdlog::info("    pxr.vendorhw.product.model = \"{}\":", pico_model);
+		spdlog::info("    pxr.vendorhw.product.model = \"{}\":", pico_model.value_or("<unset>"));
 
 		if (pico_model == "Pico Neo 3")
-			return model::pico_neo_3;
+		{
+			traits.panel_width_override = 1832;
+			traits.controller_profile = "pico-neo3";
+		}
 
-		if (pico_model == "PICO 4")
-			return model::pico_4;
+		else if (pico_model and pico_model->starts_with("PICO 4"))
+		{
+			traits.panel_width_override = 2160;
+			if (pico_model == "PICO 4 Ultra")
+				traits.controller_profile = "pico-4u";
+			else
+				traits.controller_profile = "pico-4";
 
-		if (pico_model == "PICO 4 Ultra")
-			return model::pico_4s;
-
-		if (pico_model == "PICO 4 Pro")
-			return model::pico_4_pro;
-
-		if (pico_model == "PICO 4 Enterprise")
-			return model::pico_4_enterprise;
-
-		spdlog::info("manufacturer={}, model={}, device={}, pico_model={} assuming Pico 4", manufacturer, model, device, pico_model);
-		return model::pico_4;
+			if (pico_model == "PICO 4 Pro" or pico_model == "PICO 4 Enterprise")
+				traits.pico_face_tracker = true;
+		}
 	}
 	if (manufacturer == "HTC")
 	{
+		// Accepts OpenXR 1.1 but doesn't actually implement it
+		traits.max_openxr_api_version = XR_API_VERSION_1_0;
+		// Doesn't handle additive blend, so needs specific ray model
+		traits.controller_ray_model = "assets://ray-htc.glb";
+
+		traits.controller_profile = "htc-vive-focus-3";
+
 		if (model == "VIVE Focus 3")
-			return model::htc_vive_focus_3;
+			traits.panel_width_override = 2448;
 
 		if (model == "VIVE Focus Vision")
-			return model::htc_vive_focus_vision;
+			traits.panel_width_override = 2448;
 
 		if (model == "VIVE XR Series")
-			return model::htc_vive_xr_elite;
+			traits.panel_width_override = 1920;
 	}
 	if (manufacturer == "samsung")
 	{
-		if (model == "SM-I610")
-			return model::samsung_galaxy_xr;
-	}
-
-	spdlog::info("Unknown model, manufacturer={}, model={}, device={}", manufacturer, model, device);
-#endif
-	return model::unknown;
-}
-
-model guess_model()
-{
-	static model m = guess_model_();
-	return m;
-}
-
-const char * permission_name_for_hmd(const hmd_traits & traits, const feature f)
-{
-	if (f == feature::microphone)
-		return "android.permission.RECORD_AUDIO";
-
-	if (!traits.permissions)
-		return nullptr;
-
-	return (*traits.permissions)[f];
-}
-
-static std::optional<uint32_t> env_u32(const char * env_name, const char * android_sysprop_name)
-{
-#ifdef __ANDROID__
-	const std::string value = get_property(android_sysprop_name);
-#else
-	const char * env_value = std::getenv(env_name);
-	const std::string value = (env_value != nullptr) ? std::string(env_value) : std::string();
-#endif
-	if (value.empty())
-		return std::nullopt;
-	char * end = nullptr;
-	const unsigned long parsed = std::strtoul(value.c_str(), &end, 10);
-	if (end == value.c_str() || *end != '\0')
-		return std::nullopt;
-	if (parsed > std::numeric_limits<uint32_t>::max())
-		return std::nullopt;
-	return static_cast<uint32_t>(parsed);
-}
-
-static std::optional<bool> env_bool(const char * env_name, const char * android_sysprop_name)
-{
-#ifdef __ANDROID__
-	const std::string value = get_property(android_sysprop_name);
-#else
-	const char * env_value = std::getenv(env_name);
-	const std::string value = (env_value != nullptr) ? std::string(env_value) : std::string();
-#endif
-	if (value.empty())
-		return std::nullopt;
-	if (strcmp(value.c_str(), "1") == 0 || strcasecmp(value.c_str(), "true") == 0 || strcasecmp(value.c_str(), "yes") == 0 || strcasecmp(value.c_str(), "on") == 0)
-		return true;
-	if (strcmp(value.c_str(), "0") == 0 || strcasecmp(value.c_str(), "false") == 0 || strcasecmp(value.c_str(), "no") == 0 || strcasecmp(value.c_str(), "off") == 0)
-		return false;
-	return std::nullopt;
-}
-
-static std::optional<std::string> env_string(const char * env_name, const char * android_sysprop_name)
-{
-#ifdef __ANDROID__
-	const std::string value = get_property(android_sysprop_name);
-	if (!value.empty())
-		return value;
-	return std::nullopt;
-#else
-	const char * value = std::getenv(env_name);
-	if (value != nullptr)
-		return std::string(value);
-	return std::nullopt;
-#endif
-}
-
-static const hmd_permissions permission_quest = [] {
-	hmd_permissions permissions{};
-	permissions[feature::eye_gaze] = "com.oculus.permission.EYE_TRACKING";
-	permissions[feature::face_tracking] = "com.oculus.permission.FACE_TRACKING";
-	return permissions;
-}();
-static const hmd_permissions permission_pico = [] {
-	hmd_permissions permissions{};
-	permissions[feature::eye_gaze] = "com.picovr.permission.EYE_TRACKING";
-	permissions[feature::face_tracking] = "com.picovr.permission.FACE_TRACKING";
-	return permissions;
-}();
-static const hmd_permissions permission_samsung = [] {
-	hmd_permissions permissions{};
-	permissions[feature::hand_tracking] = "android.permission.HAND_TRACKING";
-	permissions[feature::eye_gaze] = "android.permission.EYE_TRACKING_FINE";
-	permissions[feature::face_tracking] = "android.permission.FACE_TRACKING";
-	return permissions;
-}();
-static const hmd_permissions permission_quest_body = [] {
-	hmd_permissions permissions{};
-	permissions[feature::eye_gaze] = "com.oculus.permission.EYE_TRACKING";
-	permissions[feature::face_tracking] = "com.oculus.permission.FACE_TRACKING";
-	permissions[feature::body_tracking] = "com.oculus.permission.BODY_TRACKING";
-	return permissions;
-}();
-
-static hmd_traits get_hmd_traits(const model m)
-{
-	hmd_traits traits{};
-	switch (m)
-	{
-		case model::oculus_quest:
-			traits.panel_width_override = 1440;
-			traits.controller_profile = "oculus-touch-v2";
-			traits.permissions = &permission_quest;
-			break;
-		case model::oculus_quest_2:
-			traits.panel_width_override = 1832;
-			traits.controller_profile = "oculus-touch-v3";
-			traits.permissions = &permission_quest;
-			break;
-		case model::meta_quest_pro:
-			traits.panel_width_override = 1800;
-			traits.controller_profile = "meta-quest-touch-pro";
-			traits.permissions = &permission_quest;
-			break;
-		case model::meta_quest_3:
-			traits.controller_profile = "meta-quest-touch-plus";
-			traits.panel_width_override = 2064;
-			traits.permissions = &permission_quest_body;
-			break;
-		case model::meta_quest_3s:
-			traits.panel_width_override = 1832;
-			traits.controller_profile = "meta-quest-touch-plus";
-			traits.permissions = &permission_quest_body;
-			break;
-		case model::pico_neo_3:
-			traits.panel_width_override = 1832;
-			traits.controller_profile = "pico-neo3";
-			traits.permissions = &permission_pico;
-			break;
-		case model::pico_4:
-		case model::pico_4_pro:
-		case model::pico_4_enterprise:
-			traits.panel_width_override = 2160;
-			traits.controller_profile = "pico-4";
-			traits.permissions = &permission_pico;
-			break;
-		case model::pico_4s:
-			traits.panel_width_override = 2160;
-			traits.controller_profile = "pico-4u";
-			traits.permissions = &permission_pico;
-			break;
-		case model::htc_vive_focus_3:
-			traits.panel_width_override = 2448;
-			traits.max_openxr_api_version = XR_API_VERSION_1_0;
-			traits.controller_profile = "htc-vive-focus-3";
-			traits.controller_ray_model = "assets://ray-htc.glb";
-			break;
-		case model::htc_vive_xr_elite:
-			traits.panel_width_override = 1920;
-			traits.max_openxr_api_version = XR_API_VERSION_1_0;
-			traits.controller_profile = "htc-vive-focus-3";
-			traits.controller_ray_model = "assets://ray-htc.glb";
-			break;
-		case model::htc_vive_focus_vision:
-			traits.panel_width_override = 2448;
-			traits.max_openxr_api_version = XR_API_VERSION_1_0;
-			traits.controller_profile = "htc-vive-focus-3";
-			traits.controller_ray_model = "assets://ray-htc.glb";
-			break;
-		case model::lynx_r1:
-			traits.needs_srgb_conversion = false;
-			break;
-		case model::samsung_galaxy_xr:
+		if (model == "SM-I610") // Galaxy XR
+		{
 			traits.panel_width_override = 3552;
 			traits.controller_profile = "samsung-galaxyxr";
-			traits.permissions = &permission_samsung;
-			break;
-		case model::unknown:
-			break;
+			traits.permissions[feature::hand_tracking] = "android.permission.HAND_TRACKING";
+			traits.permissions[feature::eye_gaze] = "android.permission.EYE_TRACKING_FINE";
+			traits.permissions[feature::face_tracking] = "android.permission.FACE_TRACKING";
+		}
+	}
+#endif
+
+	if (auto panel_width = env_u32("WIVRN_QUIRK_PANEL_WIDTH", "debug.wivrn.quirk_panel_width"))
+	{
+		spdlog::info("panel width override: {} -> {}", traits.panel_width_override, *panel_width);
+		traits.panel_width_override = *panel_width;
 	}
 
-	return traits;
-}
+	if (auto disable_openxr_1_1 = env_bool("WIVRN_QUIRK_DISABLE_OPENXR_1_1", "debug.wivrn.quirk_disable_openxr_1_1"))
+	{
+		auto old = traits.max_openxr_api_version;
+		traits.max_openxr_api_version = *disable_openxr_1_1 ? XR_API_VERSION_1_0 : XR_API_VERSION_1_1;
+		spdlog::info("max OpenXR version override: {} -> {}", xr::to_string(old), xr::to_string(traits.max_openxr_api_version));
+	}
 
-namespace
-{
-hmd_traits g_hmd_traits;
-std::string g_controller_override_storage;
-} // namespace
+	if (auto srgb = env_bool("WIVRN_QUIRK_SRGB_CONVERSION", "debug.wivrn.quirk_srgb_conversion"))
+	{
+		spdlog::info("srgb conversion override: {} -> {}", traits.needs_srgb_conversion, *srgb);
+		traits.needs_srgb_conversion = *srgb;
+	}
 
-void initialize_runtime_hmd_traits()
-{
-	hmd_traits q = get_hmd_traits(guess_model());
-	const std::optional<uint32_t> panel_width = env_u32("WIVRN_QUIRK_PANEL_WIDTH", "debug.wivrn.quirk_panel_width");
-	const bool had_panel_override = panel_width.has_value();
-	q.panel_width_override = panel_width.value_or(q.panel_width_override);
-	const std::optional<bool> disable_openxr_1_1_override = env_bool("WIVRN_QUIRK_DISABLE_OPENXR_1_1", "debug.wivrn.quirk_disable_openxr_1_1");
-	const bool disable_openxr_1_1 = disable_openxr_1_1_override.value_or(q.max_openxr_api_version < XR_API_VERSION_1_1);
-	q.max_openxr_api_version = disable_openxr_1_1 ? XR_API_VERSION_1_0 : XR_API_VERSION_1_1;
-	const std::optional<bool> srgb_override = env_bool("WIVRN_QUIRK_SRGB_CONVERSION", "debug.wivrn.quirk_srgb_conversion");
-	const bool srgb = srgb_override.value_or(q.needs_srgb_conversion);
-	const bool had_srgb_override = srgb_override.has_value();
-	q.needs_srgb_conversion = srgb;
-	g_controller_override_storage = env_string("WIVRN_CONTROLLER", "debug.wivrn.controller").value_or(std::string(q.controller_profile));
-	const bool had_controller_override = g_controller_override_storage != q.controller_profile;
-	q.controller_profile = g_controller_override_storage.c_str();
+	if (auto controller = env_string("WIVRN_CONTROLLER", "debug.wivrn.controller"))
+	{
+		spdlog::info("controller override: {} -> {}", traits.controller_profile, *controller);
+		traits.controller_profile = *controller;
+	}
+
 	spdlog::info("Initialized HMD traits: profile={}, ray_model={}, panel_width_override={}, max_openxr_api={}, needs_srgb_conversion={}",
-	             q.controller_profile,
-	             q.controller_ray_model,
-	             q.panel_width_override,
-	             xr::to_string(q.max_openxr_api_version),
-	             q.needs_srgb_conversion);
-	spdlog::info("HMD trait overrides: panel_width={}, disable_openxr_1_1={}, srgb_conversion={}, controller_profile={}",
-	             had_panel_override,
-	             disable_openxr_1_1_override.has_value(),
-	             had_srgb_override,
-	             had_controller_override);
-	q.is_initialized = true;
-	g_hmd_traits = q;
-}
+	             traits.controller_profile,
+	             traits.controller_ray_model,
+	             traits.panel_width_override,
+	             xr::to_string(traits.max_openxr_api_version),
+	             traits.needs_srgb_conversion);
 
-const hmd_traits & runtime_hmd_traits()
-{
-	// runtime_hmd_traits() must only be accessed after initialization has completed.
-	assert(g_hmd_traits.is_initialized && "runtime_hmd_traits() accessed before initialize_runtime_hmd_traits() completed");
-	return g_hmd_traits;
-}
+	return traits;
+}();
 
 std::string model_name()
 {
 #ifdef __ANDROID__
-	const auto manufacturer = get_property("ro.product.manufacturer");
-	const auto model = get_property("ro.product.model");
+	const auto manufacturer = get_property("ro.product.manufacturer").value_or("");
+	const auto model = get_property("ro.product.model").value_or("");
 
 	return manufacturer + " " + model;
 #else
@@ -360,14 +275,14 @@ static XrViewConfigurationView scale_view(XrViewConfigurationView view, uint32_t
 	return view;
 }
 
-XrViewConfigurationView override_view_for_hmd(const hmd_traits & traits, XrViewConfigurationView view)
+XrViewConfigurationView hmd_traits_t::override_view_for_hmd(XrViewConfigurationView view) const
 {
 	// Standalone headsets tend to report a lower resolution
 	// as the GPU can't handle full res.
 	// Return the panel resolution instead.
 	spdlog::debug("Recommended image size: {}x{}", view.recommendedImageRectWidth, view.recommendedImageRectHeight);
-	if (traits.panel_width_override > 0)
-		return scale_view(view, traits.panel_width_override);
+	if (panel_width_override > 0)
+		return scale_view(view, panel_width_override);
 	return view;
 }
 

--- a/client/hardware.cpp
+++ b/client/hardware.cpp
@@ -127,20 +127,13 @@ model guess_model()
 
 const char * permission_name_for_hmd(const hmd_traits & traits, const feature f)
 {
-	switch (f)
-	{
-		case feature::microphone:
-			return "android.permission.RECORD_AUDIO";
-		case feature::hand_tracking:
-			return traits.permissions ? traits.permissions->hand_tracking : nullptr;
-		case feature::eye_gaze:
-			return traits.permissions ? traits.permissions->eye_gaze : nullptr;
-		case feature::face_tracking:
-			return traits.permissions ? traits.permissions->face_tracking : nullptr;
-		case feature::body_tracking:
-			return traits.permissions ? traits.permissions->body_tracking : nullptr;
-	}
-	__builtin_unreachable();
+	if (f == feature::microphone)
+		return "android.permission.RECORD_AUDIO";
+
+	if (!traits.permissions)
+		return nullptr;
+
+	return (*traits.permissions)[f];
 }
 
 static uint32_t env_u32(const char * env_name, const char * android_sysprop_name)
@@ -188,24 +181,32 @@ static std::string env_string(const char * env_name, const char * android_syspro
 #endif
 }
 
-static const hmd_permissions permission_quest{
-        .eye_gaze = "com.oculus.permission.EYE_TRACKING",
-        .face_tracking = "com.oculus.permission.FACE_TRACKING",
-};
-static const hmd_permissions permission_pico{
-        .eye_gaze = "com.picovr.permission.EYE_TRACKING",
-        .face_tracking = "com.picovr.permission.FACE_TRACKING",
-};
-static const hmd_permissions permission_samsung{
-        .hand_tracking = "android.permission.HAND_TRACKING",
-        .eye_gaze = "android.permission.EYE_TRACKING_FINE",
-        .face_tracking = "android.permission.FACE_TRACKING",
-};
-static const hmd_permissions permission_quest_body{
-        .eye_gaze = "com.oculus.permission.EYE_TRACKING",
-        .face_tracking = "com.oculus.permission.FACE_TRACKING",
-        .body_tracking = "com.oculus.permission.BODY_TRACKING",
-};
+static const hmd_permissions permission_quest = [] {
+	hmd_permissions permissions{};
+	permissions[feature::eye_gaze] = "com.oculus.permission.EYE_TRACKING";
+	permissions[feature::face_tracking] = "com.oculus.permission.FACE_TRACKING";
+	return permissions;
+}();
+static const hmd_permissions permission_pico = [] {
+	hmd_permissions permissions{};
+	permissions[feature::eye_gaze] = "com.picovr.permission.EYE_TRACKING";
+	permissions[feature::face_tracking] = "com.picovr.permission.FACE_TRACKING";
+	return permissions;
+}();
+static const hmd_permissions permission_samsung = [] {
+	hmd_permissions permissions{};
+	permissions[feature::hand_tracking] = "android.permission.HAND_TRACKING";
+	permissions[feature::eye_gaze] = "android.permission.EYE_TRACKING_FINE";
+	permissions[feature::face_tracking] = "android.permission.FACE_TRACKING";
+	return permissions;
+}();
+static const hmd_permissions permission_quest_body = [] {
+	hmd_permissions permissions{};
+	permissions[feature::eye_gaze] = "com.oculus.permission.EYE_TRACKING";
+	permissions[feature::face_tracking] = "com.oculus.permission.FACE_TRACKING";
+	permissions[feature::body_tracking] = "com.oculus.permission.BODY_TRACKING";
+	return permissions;
+}();
 
 static hmd_traits get_hmd_traits(const model m)
 {

--- a/client/hardware.cpp
+++ b/client/hardware.cpp
@@ -102,9 +102,25 @@ static std::optional<bool> env_bool(const char * env_name, const char * android_
 	return std::nullopt;
 }
 
-const hmd_traits_t hmd_traits = [] {
-	hmd_traits_t traits{};
+static hmd_traits_t traits;
+#ifndef NDEBUG
+static bool initialized = false;
+#endif
 
+const hmd_traits_t & hmd_traits()
+{
+#ifndef NDEBUG
+	assert(initialized);
+#endif
+	return traits;
+}
+
+void hmd_traits_init()
+{
+#ifndef NDEBUG
+	assert(not initialized);
+	initialized = true;
+#endif
 #ifdef __ANDROID__
 	const auto device = get_property("ro.product.device");
 	const auto manufacturer = get_property("ro.product.manufacturer");
@@ -251,9 +267,7 @@ const hmd_traits_t hmd_traits = [] {
 	             traits.panel_width_override,
 	             xr::to_string(traits.max_openxr_api_version),
 	             traits.needs_srgb_conversion);
-
-	return traits;
-}();
+};
 
 std::string model_name()
 {

--- a/client/hardware.cpp
+++ b/client/hardware.cpp
@@ -275,7 +275,7 @@ static XrViewConfigurationView scale_view(XrViewConfigurationView view, uint32_t
 	return view;
 }
 
-XrViewConfigurationView hmd_traits_t::override_view_for_hmd(XrViewConfigurationView view) const
+XrViewConfigurationView hmd_traits_t::override_view(XrViewConfigurationView view) const
 {
 	// Standalone headsets tend to report a lower resolution
 	// as the GPU can't handle full res.

--- a/client/hardware.cpp
+++ b/client/hardware.cpp
@@ -18,8 +18,11 @@
  */
 
 #include "hardware.h"
+
+#include "utils/overloaded.h"
 #include "xr/to_string.h"
 
+#include <boost/pfr.hpp>
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
@@ -50,21 +53,26 @@ static std::optional<std::string> get_property(const char * property)
 }
 #endif
 
-static std::optional<std::string> env_string(const char * env_name, const char * android_sysprop_name)
+static std::optional<std::string> env_string(std::string_view name)
 {
 #ifdef __ANDROID__
-	return get_property(android_sysprop_name);
+	auto android_sysprop_name = std::format("wivrn.debug.{}", name);
+	return get_property(android_sysprop_name.c_str());
 #else
-	const char * value = std::getenv(env_name);
+	std::string env_name = "WIVRN_";
+	env_name.reserve(env_name.size() + name.size());
+	for (const auto & c: name)
+		env_name += std::toupper(c);
+	const char * value = std::getenv(env_name.c_str());
 	if (value)
 		return value;
 	return std::nullopt;
 #endif
 }
 
-static std::optional<uint32_t> env_u32(const char * env_name, const char * android_sysprop_name)
+static std::optional<uint32_t> env_u32(std::string_view name)
 {
-	const auto value = env_string(env_name, android_sysprop_name);
+	const auto value = env_string(name);
 	if (not value)
 		return std::nullopt;
 	try
@@ -76,23 +84,14 @@ static std::optional<uint32_t> env_u32(const char * env_name, const char * andro
 	}
 	catch (std::runtime_error & e)
 	{
-		spdlog::warn("failed to parse {} (value: {}: {}",
-#ifdef __ANDROID__
-		             android_sysprop_name,
-#else
-		             env_name,
-#endif
-		             *value,
-		             e.what()
-
-		);
+		spdlog::warn("failed to parse {} (value: {}: {}", name, *value, e.what());
 		return std::nullopt;
 	}
 }
 
-static std::optional<bool> env_bool(const char * env_name, const char * android_sysprop_name)
+static std::optional<bool> env_bool(std::string_view name)
 {
-	const auto value = env_string(env_name, android_sysprop_name);
+	const auto value = env_string(name);
 	if (not value)
 		return std::nullopt;
 	if (strcmp(value->c_str(), "1") == 0 || strcasecmp(value->c_str(), "true") == 0 || strcasecmp(value->c_str(), "yes") == 0 || strcasecmp(value->c_str(), "on") == 0)
@@ -236,37 +235,66 @@ void hmd_traits_init()
 	}
 #endif
 
-	if (auto panel_width = env_u32("WIVRN_QUIRK_PANEL_WIDTH", "debug.wivrn.quirk_panel_width"))
-	{
-		spdlog::info("panel width override: {} -> {}", traits.panel_width_override, *panel_width);
-		traits.panel_width_override = *panel_width;
-	}
-
-	if (auto disable_openxr_1_1 = env_bool("WIVRN_QUIRK_DISABLE_OPENXR_1_1", "debug.wivrn.quirk_disable_openxr_1_1"))
-	{
-		auto old = traits.max_openxr_api_version;
-		traits.max_openxr_api_version = *disable_openxr_1_1 ? XR_API_VERSION_1_0 : XR_API_VERSION_1_1;
-		spdlog::info("max OpenXR version override: {} -> {}", xr::to_string(old), xr::to_string(traits.max_openxr_api_version));
-	}
-
-	if (auto srgb = env_bool("WIVRN_QUIRK_SRGB_CONVERSION", "debug.wivrn.quirk_srgb_conversion"))
-	{
-		spdlog::info("srgb conversion override: {} -> {}", traits.needs_srgb_conversion, *srgb);
-		traits.needs_srgb_conversion = *srgb;
-	}
-
-	if (auto controller = env_string("WIVRN_CONTROLLER", "debug.wivrn.controller"))
-	{
-		spdlog::info("controller override: {} -> {}", traits.controller_profile, *controller);
-		traits.controller_profile = *controller;
-	}
-
-	spdlog::info("Initialized HMD traits: profile={}, ray_model={}, panel_width_override={}, max_openxr_api={}, needs_srgb_conversion={}",
-	             traits.controller_profile,
-	             traits.controller_ray_model,
-	             traits.panel_width_override,
-	             xr::to_string(traits.max_openxr_api_version),
-	             traits.needs_srgb_conversion);
+	spdlog::info("HMD traits initialized");
+	boost::pfr::for_each_field_with_name(
+	        traits,
+	        utils::overloaded{
+	                [](std::string_view name, std::string & field) {
+		                if (auto val = env_string(name))
+		                {
+			                spdlog::info("\t{} override: {} -> {}", name, field, *val);
+			                field = *val;
+		                }
+		                else
+		                {
+			                spdlog::info("\t{}: {}", name, field);
+		                }
+	                },
+	                [](std::string_view name, uint32_t & field) {
+		                if (auto val = env_u32(name))
+		                {
+			                spdlog::info("\t{} override: {} -> {}", name, field, *val);
+			                field = *val;
+		                }
+		                else
+		                {
+			                spdlog::info("\t{}: {}", name, field);
+		                }
+	                },
+	                [](std::string_view name, bool & field) {
+		                if (auto val = env_bool(name))
+		                {
+			                spdlog::info("\t{} override: {} -> {}", name, field, *val);
+			                field = *val;
+		                }
+		                else
+		                {
+			                spdlog::info("\t{}: {}", name, field);
+		                }
+	                },
+	                [](std::string_view name, XrVersion & field) {
+		                if (auto val = env_string(name))
+		                {
+			                XrVersion v;
+			                if (val == "1.1")
+				                v = XR_API_VERSION_1_1;
+			                else if (val == "1.0")
+				                v = XR_API_VERSION_1_0;
+			                else
+			                {
+				                spdlog::warn("XrVersion {} not recognized", *val);
+				                return;
+			                }
+			                spdlog::info("\t{} override: {} -> {}", name, xr::to_string(field), xr::to_string(v));
+			                field = v;
+		                }
+		                else
+		                {
+			                spdlog::info("\t{}: {}", name, xr::to_string(field));
+		                }
+	                },
+	                [](std::string_view name, hmd_permissions &) {
+	                }});
 };
 
 std::string model_name()

--- a/client/hardware.cpp
+++ b/client/hardware.cpp
@@ -23,6 +23,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <glm/ext/quaternion_trigonometric.hpp>
+#include <limits>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -136,48 +137,54 @@ const char * permission_name_for_hmd(const hmd_traits & traits, const feature f)
 	return (*traits.permissions)[f];
 }
 
-static uint32_t env_u32(const char * env_name, const char * android_sysprop_name)
+static std::optional<uint32_t> env_u32(const char * env_name, const char * android_sysprop_name)
 {
 #ifdef __ANDROID__
 	const std::string value = get_property(android_sysprop_name);
 #else
 	const char * env_value = std::getenv(env_name);
-	const std::string value = (env_value != nullptr && *env_value != '\0') ? std::string(env_value) : std::string();
+	const std::string value = (env_value != nullptr) ? std::string(env_value) : std::string();
 #endif
 	if (value.empty())
-		return 0;
-	return std::strtoul(value.c_str(), nullptr, 10);
+		return std::nullopt;
+	char * end = nullptr;
+	const unsigned long parsed = std::strtoul(value.c_str(), &end, 10);
+	if (end == value.c_str() || *end != '\0')
+		return std::nullopt;
+	if (parsed > std::numeric_limits<uint32_t>::max())
+		return std::nullopt;
+	return static_cast<uint32_t>(parsed);
 }
 
-static bool env_bool(const char * env_name, const char * android_sysprop_name, bool fallback)
+static std::optional<bool> env_bool(const char * env_name, const char * android_sysprop_name)
 {
 #ifdef __ANDROID__
 	const std::string value = get_property(android_sysprop_name);
 #else
 	const char * env_value = std::getenv(env_name);
-	const std::string value = (env_value != nullptr && *env_value != '\0') ? std::string(env_value) : std::string();
+	const std::string value = (env_value != nullptr) ? std::string(env_value) : std::string();
 #endif
 	if (value.empty())
-		return fallback;
+		return std::nullopt;
 	if (strcmp(value.c_str(), "1") == 0 || strcasecmp(value.c_str(), "true") == 0 || strcasecmp(value.c_str(), "yes") == 0 || strcasecmp(value.c_str(), "on") == 0)
 		return true;
 	if (strcmp(value.c_str(), "0") == 0 || strcasecmp(value.c_str(), "false") == 0 || strcasecmp(value.c_str(), "no") == 0 || strcasecmp(value.c_str(), "off") == 0)
 		return false;
-	return fallback;
+	return std::nullopt;
 }
 
-static std::string env_string(const char * env_name, const char * android_sysprop_name, const char * fallback)
+static std::optional<std::string> env_string(const char * env_name, const char * android_sysprop_name)
 {
 #ifdef __ANDROID__
 	const std::string value = get_property(android_sysprop_name);
 	if (!value.empty())
 		return value;
-	return std::string(fallback ? fallback : "");
+	return std::nullopt;
 #else
 	const char * value = std::getenv(env_name);
-	if (value != nullptr && *value != '\0')
+	if (value != nullptr)
 		return std::string(value);
-	return std::string(fallback ? fallback : "");
+	return std::nullopt;
 #endif
 }
 
@@ -300,16 +307,17 @@ void initialize_runtime_hmd_traits()
 		return;
 
 	hmd_traits q = get_hmd_traits(guess_model());
-	const uint32_t panel_width = env_u32("WIVRN_QUIRK_PANEL_WIDTH", "debug.wivrn.quirk_panel_width");
-	const bool had_panel_override = panel_width > 0;
-	if (had_panel_override)
-		q.panel_width_override = panel_width;
-	const bool disable_openxr_1_1 = env_bool("WIVRN_QUIRK_DISABLE_OPENXR_1_1", "debug.wivrn.quirk_disable_openxr_1_1", q.max_openxr_api_version < XR_API_VERSION_1_1);
+	const std::optional<uint32_t> panel_width = env_u32("WIVRN_QUIRK_PANEL_WIDTH", "debug.wivrn.quirk_panel_width");
+	const bool had_panel_override = panel_width.has_value();
+	q.panel_width_override = panel_width.value_or(q.panel_width_override);
+	const std::optional<bool> disable_openxr_1_1_override = env_bool("WIVRN_QUIRK_DISABLE_OPENXR_1_1", "debug.wivrn.quirk_disable_openxr_1_1");
+	const bool disable_openxr_1_1 = disable_openxr_1_1_override.value_or(q.max_openxr_api_version < XR_API_VERSION_1_1);
 	q.max_openxr_api_version = disable_openxr_1_1 ? XR_API_VERSION_1_0 : XR_API_VERSION_1_1;
-	const bool srgb = env_bool("WIVRN_QUIRK_SRGB_CONVERSION", "debug.wivrn.quirk_srgb_conversion", q.needs_srgb_conversion);
-	const bool had_srgb_override = srgb != q.needs_srgb_conversion;
+	const std::optional<bool> srgb_override = env_bool("WIVRN_QUIRK_SRGB_CONVERSION", "debug.wivrn.quirk_srgb_conversion");
+	const bool srgb = srgb_override.value_or(q.needs_srgb_conversion);
+	const bool had_srgb_override = srgb_override.has_value();
 	q.needs_srgb_conversion = srgb;
-	g_controller_override_storage = env_string("WIVRN_CONTROLLER", "debug.wivrn.controller", q.controller_profile);
+	g_controller_override_storage = env_string("WIVRN_CONTROLLER", "debug.wivrn.controller").value_or(std::string(q.controller_profile));
 	const bool had_controller_override = g_controller_override_storage != q.controller_profile;
 	q.controller_profile = g_controller_override_storage.c_str();
 	spdlog::info("Initialized HMD traits: profile={}, ray_model={}, panel_width_override={}, max_openxr_api={}, needs_srgb_conversion={}",
@@ -320,7 +328,7 @@ void initialize_runtime_hmd_traits()
 	             q.needs_srgb_conversion);
 	spdlog::info("HMD trait overrides: panel_width={}, disable_openxr_1_1={}, srgb_conversion={}, controller_profile={}",
 	             had_panel_override,
-	             !env_string("WIVRN_QUIRK_DISABLE_OPENXR_1_1", "debug.wivrn.quirk_disable_openxr_1_1", "").empty(),
+	             disable_openxr_1_1_override.has_value(),
 	             had_srgb_override,
 	             had_controller_override);
 	g_hmd_traits = q;

--- a/client/hardware.cpp
+++ b/client/hardware.cpp
@@ -20,11 +20,11 @@
 #include "hardware.h"
 #include "xr/to_string.h"
 
+#include <cassert>
 #include <cstdlib>
 #include <cstring>
 #include <glm/ext/quaternion_trigonometric.hpp>
 #include <limits>
-#include <optional>
 #include <stdexcept>
 #include <string>
 
@@ -297,15 +297,12 @@ static hmd_traits get_hmd_traits(const model m)
 
 namespace
 {
-std::optional<hmd_traits> g_hmd_traits;
+hmd_traits g_hmd_traits;
 std::string g_controller_override_storage;
 } // namespace
 
 void initialize_runtime_hmd_traits()
 {
-	if (g_hmd_traits.has_value())
-		return;
-
 	hmd_traits q = get_hmd_traits(guess_model());
 	const std::optional<uint32_t> panel_width = env_u32("WIVRN_QUIRK_PANEL_WIDTH", "debug.wivrn.quirk_panel_width");
 	const bool had_panel_override = panel_width.has_value();
@@ -331,17 +328,15 @@ void initialize_runtime_hmd_traits()
 	             disable_openxr_1_1_override.has_value(),
 	             had_srgb_override,
 	             had_controller_override);
+	q.is_initialized = true;
 	g_hmd_traits = q;
 }
 
 const hmd_traits & runtime_hmd_traits()
 {
-	if (!g_hmd_traits.has_value())
-	{
-		spdlog::critical("runtime_hmd_traits() accessed before initialize_runtime_hmd_traits(); falling back to lazy initialization. This is a bug!");
-		initialize_runtime_hmd_traits();
-	}
-	return *g_hmd_traits;
+	// runtime_hmd_traits() must only be accessed after initialization has completed.
+	assert(g_hmd_traits.is_initialized && "runtime_hmd_traits() accessed before initialize_runtime_hmd_traits() completed");
+	return g_hmd_traits;
 }
 
 std::string model_name()

--- a/client/hardware.cpp
+++ b/client/hardware.cpp
@@ -167,6 +167,7 @@ const hmd_traits_t hmd_traits = [] {
 		traits.permissions[feature::eye_gaze] = "com.picovr.permission.EYE_TRACKING";
 		traits.permissions[feature::face_tracking] = "com.picovr.permission.FACE_TRACKING";
 		traits.view_locate = false;
+		traits.discard_frame = false;
 		const auto pico_model = get_property("pxr.vendorhw.product.model");
 		spdlog::info("    pxr.vendorhw.product.model = \"{}\":", pico_model.value_or("<unset>"));
 

--- a/client/hardware.cpp
+++ b/client/hardware.cpp
@@ -356,15 +356,14 @@ static XrViewConfigurationView scale_view(XrViewConfigurationView view, uint32_t
 	return view;
 }
 
-XrViewConfigurationView override_view(XrViewConfigurationView view, model m)
+XrViewConfigurationView override_view_for_hmd(const hmd_traits & traits, XrViewConfigurationView view)
 {
 	// Standalone headsets tend to report a lower resolution
 	// as the GPU can't handle full res.
 	// Return the panel resolution instead.
 	spdlog::debug("Recommended image size: {}x{}", view.recommendedImageRectWidth, view.recommendedImageRectHeight);
-	const hmd_traits quirks = get_hmd_traits(m);
-	if (quirks.panel_width_override > 0)
-		return scale_view(view, quirks.panel_width_override);
+	if (traits.panel_width_override > 0)
+		return scale_view(view, traits.panel_width_override);
 	return view;
 }
 

--- a/client/hardware.cpp
+++ b/client/hardware.cpp
@@ -18,9 +18,12 @@
  */
 
 #include "hardware.h"
+#include "xr/to_string.h"
 
 #include <cstdlib>
+#include <cstring>
 #include <glm/ext/quaternion_trigonometric.hpp>
+#include <optional>
 #include <stdexcept>
 #include <string>
 
@@ -122,6 +125,216 @@ model guess_model()
 	return m;
 }
 
+const char * permission_name_for_hmd(const hmd_traits & traits, const feature f)
+{
+	switch (f)
+	{
+		case feature::microphone:
+			return "android.permission.RECORD_AUDIO";
+		case feature::hand_tracking:
+			return traits.permissions ? traits.permissions->hand_tracking : nullptr;
+		case feature::eye_gaze:
+			return traits.permissions ? traits.permissions->eye_gaze : nullptr;
+		case feature::face_tracking:
+			return traits.permissions ? traits.permissions->face_tracking : nullptr;
+		case feature::body_tracking:
+			return traits.permissions ? traits.permissions->body_tracking : nullptr;
+	}
+	__builtin_unreachable();
+}
+
+static uint32_t env_u32(const char * env_name, const char * android_sysprop_name)
+{
+#ifdef __ANDROID__
+	const std::string value = get_property(android_sysprop_name);
+#else
+	const char * env_value = std::getenv(env_name);
+	const std::string value = (env_value != nullptr && *env_value != '\0') ? std::string(env_value) : std::string();
+#endif
+	if (value.empty())
+		return 0;
+	return std::strtoul(value.c_str(), nullptr, 10);
+}
+
+static bool env_bool(const char * env_name, const char * android_sysprop_name, bool fallback)
+{
+#ifdef __ANDROID__
+	const std::string value = get_property(android_sysprop_name);
+#else
+	const char * env_value = std::getenv(env_name);
+	const std::string value = (env_value != nullptr && *env_value != '\0') ? std::string(env_value) : std::string();
+#endif
+	if (value.empty())
+		return fallback;
+	if (strcmp(value.c_str(), "1") == 0 || strcasecmp(value.c_str(), "true") == 0 || strcasecmp(value.c_str(), "yes") == 0 || strcasecmp(value.c_str(), "on") == 0)
+		return true;
+	if (strcmp(value.c_str(), "0") == 0 || strcasecmp(value.c_str(), "false") == 0 || strcasecmp(value.c_str(), "no") == 0 || strcasecmp(value.c_str(), "off") == 0)
+		return false;
+	return fallback;
+}
+
+static std::string env_string(const char * env_name, const char * android_sysprop_name, const char * fallback)
+{
+#ifdef __ANDROID__
+	const std::string value = get_property(android_sysprop_name);
+	if (!value.empty())
+		return value;
+	return std::string(fallback ? fallback : "");
+#else
+	const char * value = std::getenv(env_name);
+	if (value != nullptr && *value != '\0')
+		return std::string(value);
+	return std::string(fallback ? fallback : "");
+#endif
+}
+
+static const hmd_permissions permission_quest{
+        .eye_gaze = "com.oculus.permission.EYE_TRACKING",
+        .face_tracking = "com.oculus.permission.FACE_TRACKING",
+};
+static const hmd_permissions permission_pico{
+        .eye_gaze = "com.picovr.permission.EYE_TRACKING",
+        .face_tracking = "com.picovr.permission.FACE_TRACKING",
+};
+static const hmd_permissions permission_samsung{
+        .hand_tracking = "android.permission.HAND_TRACKING",
+        .eye_gaze = "android.permission.EYE_TRACKING_FINE",
+        .face_tracking = "android.permission.FACE_TRACKING",
+};
+static const hmd_permissions permission_quest_body{
+        .eye_gaze = "com.oculus.permission.EYE_TRACKING",
+        .face_tracking = "com.oculus.permission.FACE_TRACKING",
+        .body_tracking = "com.oculus.permission.BODY_TRACKING",
+};
+
+static hmd_traits get_hmd_traits(const model m)
+{
+	hmd_traits traits{};
+	switch (m)
+	{
+		case model::oculus_quest:
+			traits.panel_width_override = 1440;
+			traits.controller_profile = "oculus-touch-v2";
+			traits.permissions = &permission_quest;
+			break;
+		case model::oculus_quest_2:
+			traits.panel_width_override = 1832;
+			traits.controller_profile = "oculus-touch-v3";
+			traits.permissions = &permission_quest;
+			break;
+		case model::meta_quest_pro:
+			traits.panel_width_override = 1800;
+			traits.controller_profile = "meta-quest-touch-pro";
+			traits.permissions = &permission_quest;
+			break;
+		case model::meta_quest_3:
+			traits.controller_profile = "meta-quest-touch-plus";
+			traits.panel_width_override = 2064;
+			traits.permissions = &permission_quest_body;
+			break;
+		case model::meta_quest_3s:
+			traits.panel_width_override = 1832;
+			traits.controller_profile = "meta-quest-touch-plus";
+			traits.permissions = &permission_quest_body;
+			break;
+		case model::pico_neo_3:
+			traits.panel_width_override = 1832;
+			traits.controller_profile = "pico-neo3";
+			traits.permissions = &permission_pico;
+			break;
+		case model::pico_4:
+		case model::pico_4_pro:
+		case model::pico_4_enterprise:
+			traits.panel_width_override = 2160;
+			traits.controller_profile = "pico-4";
+			traits.permissions = &permission_pico;
+			break;
+		case model::pico_4s:
+			traits.panel_width_override = 2160;
+			traits.controller_profile = "pico-4u";
+			traits.permissions = &permission_pico;
+			break;
+		case model::htc_vive_focus_3:
+			traits.panel_width_override = 2448;
+			traits.max_openxr_api_version = XR_API_VERSION_1_0;
+			traits.controller_profile = "htc-vive-focus-3";
+			traits.controller_ray_model = "assets://ray-htc.glb";
+			break;
+		case model::htc_vive_xr_elite:
+			traits.panel_width_override = 1920;
+			traits.max_openxr_api_version = XR_API_VERSION_1_0;
+			traits.controller_profile = "htc-vive-focus-3";
+			traits.controller_ray_model = "assets://ray-htc.glb";
+			break;
+		case model::htc_vive_focus_vision:
+			traits.panel_width_override = 2448;
+			traits.max_openxr_api_version = XR_API_VERSION_1_0;
+			traits.controller_profile = "htc-vive-focus-3";
+			traits.controller_ray_model = "assets://ray-htc.glb";
+			break;
+		case model::lynx_r1:
+			traits.needs_srgb_conversion = false;
+			break;
+		case model::samsung_galaxy_xr:
+			traits.panel_width_override = 3552;
+			traits.controller_profile = "samsung-galaxyxr";
+			traits.permissions = &permission_samsung;
+			break;
+		case model::unknown:
+			break;
+	}
+
+	return traits;
+}
+
+namespace
+{
+std::optional<hmd_traits> g_hmd_traits;
+std::string g_controller_override_storage;
+} // namespace
+
+void initialize_runtime_hmd_traits()
+{
+	if (g_hmd_traits.has_value())
+		return;
+
+	hmd_traits q = get_hmd_traits(guess_model());
+	const uint32_t panel_width = env_u32("WIVRN_QUIRK_PANEL_WIDTH", "debug.wivrn.quirk_panel_width");
+	const bool had_panel_override = panel_width > 0;
+	if (had_panel_override)
+		q.panel_width_override = panel_width;
+	const bool disable_openxr_1_1 = env_bool("WIVRN_QUIRK_DISABLE_OPENXR_1_1", "debug.wivrn.quirk_disable_openxr_1_1", q.max_openxr_api_version < XR_API_VERSION_1_1);
+	q.max_openxr_api_version = disable_openxr_1_1 ? XR_API_VERSION_1_0 : XR_API_VERSION_1_1;
+	const bool srgb = env_bool("WIVRN_QUIRK_SRGB_CONVERSION", "debug.wivrn.quirk_srgb_conversion", q.needs_srgb_conversion);
+	const bool had_srgb_override = srgb != q.needs_srgb_conversion;
+	q.needs_srgb_conversion = srgb;
+	g_controller_override_storage = env_string("WIVRN_CONTROLLER", "debug.wivrn.controller", q.controller_profile);
+	const bool had_controller_override = g_controller_override_storage != q.controller_profile;
+	q.controller_profile = g_controller_override_storage.c_str();
+	spdlog::info("Initialized HMD traits: profile={}, ray_model={}, panel_width_override={}, max_openxr_api={}, needs_srgb_conversion={}",
+	             q.controller_profile,
+	             q.controller_ray_model,
+	             q.panel_width_override,
+	             xr::to_string(q.max_openxr_api_version),
+	             q.needs_srgb_conversion);
+	spdlog::info("HMD trait overrides: panel_width={}, disable_openxr_1_1={}, srgb_conversion={}, controller_profile={}",
+	             had_panel_override,
+	             !env_string("WIVRN_QUIRK_DISABLE_OPENXR_1_1", "debug.wivrn.quirk_disable_openxr_1_1", "").empty(),
+	             had_srgb_override,
+	             had_controller_override);
+	g_hmd_traits = q;
+}
+
+const hmd_traits & runtime_hmd_traits()
+{
+	if (!g_hmd_traits.has_value())
+	{
+		spdlog::critical("runtime_hmd_traits() accessed before initialize_runtime_hmd_traits(); falling back to lazy initialization. This is a bug!");
+		initialize_runtime_hmd_traits();
+	}
+	return *g_hmd_traits;
+}
+
 std::string model_name()
 {
 #ifdef __ANDROID__
@@ -149,195 +362,10 @@ XrViewConfigurationView override_view(XrViewConfigurationView view, model m)
 	// as the GPU can't handle full res.
 	// Return the panel resolution instead.
 	spdlog::debug("Recommended image size: {}x{}", view.recommendedImageRectWidth, view.recommendedImageRectHeight);
-	switch (m)
-	{
-		case model::oculus_quest:
-			return scale_view(view, 1440);
-		case model::oculus_quest_2:
-		case model::meta_quest_3s:
-			return scale_view(view, 1832);
-		case model::meta_quest_pro:
-			return scale_view(view, 1800);
-		case model::meta_quest_3:
-			return scale_view(view, 2064);
-		case model::pico_neo_3:
-			return scale_view(view, 1832);
-		case model::pico_4:
-		case model::pico_4s:
-		case model::pico_4_pro:
-		case model::pico_4_enterprise:
-			return scale_view(view, 2160);
-		case model::htc_vive_focus_3:
-		case model::htc_vive_focus_vision:
-			return scale_view(view, 2448);
-		case model::htc_vive_xr_elite:
-			return scale_view(view, 1920);
-		case model::samsung_galaxy_xr:
-			return scale_view(view, 3552);
-		case model::lynx_r1:
-		case model::unknown:
-			return view;
-	}
-	throw std::range_error("invalid model " + std::to_string((int)m));
-}
-
-bool need_srgb_conversion(model m)
-{
-	switch (m)
-	{
-		case model::lynx_r1:
-			return false;
-		case model::oculus_quest:
-		case model::oculus_quest_2:
-		case model::meta_quest_pro:
-		case model::meta_quest_3:
-		case model::meta_quest_3s:
-		case model::pico_neo_3:
-		case model::pico_4:
-		case model::pico_4s:
-		case model::pico_4_pro:
-		case model::pico_4_enterprise:
-		case model::htc_vive_focus_3:
-		case model::htc_vive_focus_vision:
-		case model::htc_vive_xr_elite:
-		case model::samsung_galaxy_xr:
-		case model::unknown:
-			return true;
-	}
-	throw std::range_error("invalid model " + std::to_string((int)m));
-}
-
-const char * permission_name(feature f)
-{
-	switch (f)
-	{
-		case feature::microphone:
-			return "android.permission.RECORD_AUDIO";
-		case feature::hand_tracking:
-			switch (guess_model())
-			{
-				case model::samsung_galaxy_xr:
-					return "android.permission.HAND_TRACKING";
-				case model::oculus_quest:
-				case model::oculus_quest_2:
-				case model::meta_quest_pro:
-				case model::meta_quest_3:
-				case model::meta_quest_3s:
-				case model::pico_neo_3:
-				case model::pico_4:
-				case model::pico_4s:
-				case model::pico_4_pro:
-				case model::pico_4_enterprise:
-				case model::htc_vive_focus_3:
-				case model::htc_vive_focus_vision:
-				case model::htc_vive_xr_elite:
-				case model::lynx_r1:
-				case model::unknown:
-					break;
-			}
-			return nullptr;
-		case feature::eye_gaze:
-			switch (guess_model())
-			{
-				case model::oculus_quest:
-				case model::oculus_quest_2:
-				case model::meta_quest_pro:
-				case model::meta_quest_3:
-				case model::meta_quest_3s:
-					return "com.oculus.permission.EYE_TRACKING";
-				case model::pico_neo_3:
-				case model::pico_4:
-				case model::pico_4s:
-				case model::pico_4_pro:
-				case model::pico_4_enterprise:
-					return "com.picovr.permission.EYE_TRACKING";
-				case model::samsung_galaxy_xr:
-					return "android.permission.EYE_TRACKING_FINE";
-				case model::htc_vive_focus_3:
-				case model::htc_vive_focus_vision:
-				case model::htc_vive_xr_elite:
-				case model::lynx_r1:
-				case model::unknown:
-					return nullptr;
-			}
-			__builtin_unreachable();
-		case feature::face_tracking:
-			switch (guess_model())
-			{
-				case model::oculus_quest:
-				case model::oculus_quest_2:
-				case model::meta_quest_pro:
-				case model::meta_quest_3:
-				case model::meta_quest_3s:
-					return "com.oculus.permission.FACE_TRACKING";
-				case model::pico_neo_3:
-				case model::pico_4:
-				case model::pico_4s:
-				case model::pico_4_pro:
-				case model::pico_4_enterprise:
-					return "com.picovr.permission.FACE_TRACKING";
-				case model::samsung_galaxy_xr:
-					return "android.permission.FACE_TRACKING";
-				case model::htc_vive_focus_3:
-				case model::htc_vive_focus_vision:
-				case model::htc_vive_xr_elite:
-				case model::lynx_r1:
-				case model::unknown:
-					return nullptr;
-			}
-			__builtin_unreachable();
-		case feature::body_tracking:
-			switch (guess_model())
-			{
-				case model::meta_quest_3:
-				case model::meta_quest_3s:
-					return "com.oculus.permission.BODY_TRACKING";
-				default:
-					return nullptr;
-			}
-	}
-	__builtin_unreachable();
-}
-
-std::string controller_name()
-{
-#ifndef __ANDROID__
-	const char * controller = std::getenv("WIVRN_CONTROLLER");
-	if (controller && strcmp(controller, ""))
-		return controller;
-#endif
-
-	switch (guess_model())
-	{
-		case model::oculus_quest:
-			return "oculus-touch-v2";
-		case model::oculus_quest_2:
-			return "oculus-touch-v3";
-		case model::meta_quest_pro:
-			return "meta-quest-touch-pro";
-		case model::meta_quest_3:
-		case model::meta_quest_3s:
-			return "meta-quest-touch-plus";
-		case model::pico_neo_3:
-			return "pico-neo3";
-		case model::pico_4:
-		case model::pico_4_pro:
-		case model::pico_4_enterprise:
-			return "pico-4";
-		case model::pico_4s:
-			return "pico-4u";
-		case model::htc_vive_focus_3:
-		case model::htc_vive_focus_vision:
-		case model::htc_vive_xr_elite:
-			return "htc-vive-focus-3";
-		case model::samsung_galaxy_xr:
-			return "samsung-galaxyxr";
-		case model::lynx_r1:
-		case model::unknown:
-			return "generic-trigger-squeeze";
-	}
-
-	__builtin_unreachable();
+	const hmd_traits quirks = get_hmd_traits(m);
+	if (quirks.panel_width_override > 0)
+		return scale_view(view, quirks.panel_width_override);
+	return view;
 }
 
 std::pair<glm::vec3, glm::quat> controller_offset(std::string_view profile, xr::spaces space)
@@ -450,20 +478,4 @@ std::pair<glm::vec3, glm::quat> controller_offset(std::string_view profile, xr::
 		}
 
 	return {{0, 0, 0}, {1, 0, 0, 0}};
-}
-
-std::string controller_ray_model_name()
-{
-	switch (guess_model())
-	{
-		case model::htc_vive_focus_3:
-		case model::htc_vive_focus_vision:
-		case model::htc_vive_xr_elite:
-			// XR Elite's runtime always assume alpha is unpremultiplied in the composition layers
-			// Assume it's the same for all HTC headsets
-			return "assets://ray-htc.glb";
-
-		default:
-			return "assets://ray.glb";
-	}
 }

--- a/client/hardware.h
+++ b/client/hardware.h
@@ -62,20 +62,20 @@ struct hmd_traits
 {
 	const char * controller_profile = "generic-trigger-squeeze";
 	const char * controller_ray_model = "assets://ray.glb";
+	const hmd_permissions * permissions = nullptr;
 	XrVersion max_openxr_api_version = XR_API_VERSION_1_1;
 	uint32_t panel_width_override = 0;
 	bool needs_srgb_conversion = true;
-	const hmd_permissions * permissions = nullptr;
+	bool is_initialized = false;
 };
 
 model guess_model();
 std::string model_name();
 void initialize_runtime_hmd_traits();
 // Initialized once at startup (initialize_runtime_hmd_traits()).
-// If the HMD is recognized, returns traits specific to that model; otherwise,returns
+// If the HMD is recognized, returns traits specific to that model; otherwise returns
 // default behavior.
-// Fallback: if called before initialize_runtime_hmd_traits() (avoid this!), dynamically
-// constructs itself and complains in logs.
+// Must only be called after initialize_runtime_hmd_traits().
 const hmd_traits & runtime_hmd_traits();
 const char * permission_name_for_hmd(const hmd_traits & traits, const feature f);
 XrViewConfigurationView override_view_for_hmd(const hmd_traits & traits, XrViewConfigurationView);

--- a/client/hardware.h
+++ b/client/hardware.h
@@ -51,6 +51,7 @@ extern const struct hmd_traits_t
 	bool bind_simple_controller = true;
 	bool hand_interaction_grip_surface = true;
 	bool pico_face_tracker = false;
+	bool discard_frame = true; // can do xrBeginFrame twice to discard the first one
 
 	XrViewConfigurationView override_view(XrViewConfigurationView) const;
 } hmd_traits;

--- a/client/hardware.h
+++ b/client/hardware.h
@@ -27,26 +27,6 @@
 #include <utility>
 #include <openxr/openxr.h>
 
-enum class model
-{
-	oculus_quest,
-	oculus_quest_2,
-	meta_quest_pro,
-	meta_quest_3,
-	meta_quest_3s,
-	pico_neo_3,
-	pico_4,
-	pico_4s,
-	pico_4_pro,
-	pico_4_enterprise,
-	htc_vive_focus_3,
-	htc_vive_xr_elite,
-	htc_vive_focus_vision,
-	lynx_r1,
-	samsung_galaxy_xr,
-	unknown
-};
-
 enum class feature
 {
 	microphone,
@@ -58,26 +38,23 @@ enum class feature
 
 using hmd_permissions = magic_enum::containers::array<feature, const char *>;
 
-struct hmd_traits
+extern const struct hmd_traits_t
 {
-	const char * controller_profile = "generic-trigger-squeeze";
+	std::string controller_profile = "generic-trigger-squeeze";
 	const char * controller_ray_model = "assets://ray.glb";
-	const hmd_permissions * permissions = nullptr;
+	hmd_permissions permissions{};
 	XrVersion max_openxr_api_version = XR_API_VERSION_1_1;
 	uint32_t panel_width_override = 0;
 	bool needs_srgb_conversion = true;
-	bool is_initialized = false;
-};
+	bool view_locate = true; // can locate relative to view
+	bool vk_debug_ext_allowed = true;
+	bool bind_simple_controller = true;
+	bool hand_interaction_grip_surface = true;
+	bool pico_face_tracker = false;
 
-model guess_model();
+	XrViewConfigurationView override_view_for_hmd(XrViewConfigurationView) const;
+} hmd_traits;
+
 std::string model_name();
-void initialize_runtime_hmd_traits();
-// Initialized once at startup (initialize_runtime_hmd_traits()).
-// If the HMD is recognized, returns traits specific to that model; otherwise returns
-// default behavior.
-// Must only be called after initialize_runtime_hmd_traits().
-const hmd_traits & runtime_hmd_traits();
-const char * permission_name_for_hmd(const hmd_traits & traits, const feature f);
-XrViewConfigurationView override_view_for_hmd(const hmd_traits & traits, XrViewConfigurationView);
 
 std::pair<glm::vec3, glm::quat> controller_offset(std::string_view profile, xr::spaces space);

--- a/client/hardware.h
+++ b/client/hardware.h
@@ -21,6 +21,7 @@
 #include "xr/space.h"
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
+#include <magic_enum_containers.hpp>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -55,13 +56,7 @@ enum class feature
 	body_tracking,
 };
 
-struct hmd_permissions
-{
-	const char * hand_tracking = nullptr;
-	const char * eye_gaze = nullptr;
-	const char * face_tracking = nullptr;
-	const char * body_tracking = nullptr;
-};
+using hmd_permissions = magic_enum::containers::array<feature, const char *>;
 
 struct hmd_traits
 {

--- a/client/hardware.h
+++ b/client/hardware.h
@@ -83,7 +83,6 @@ void initialize_runtime_hmd_traits();
 // constructs itself and complains in logs.
 const hmd_traits & runtime_hmd_traits();
 const char * permission_name_for_hmd(const hmd_traits & traits, const feature f);
-
-XrViewConfigurationView override_view(XrViewConfigurationView, model = guess_model());
+XrViewConfigurationView override_view_for_hmd(const hmd_traits & traits, XrViewConfigurationView);
 
 std::pair<glm::vec3, glm::quat> controller_offset(std::string_view profile, xr::spaces space);

--- a/client/hardware.h
+++ b/client/hardware.h
@@ -38,7 +38,7 @@ enum class feature
 
 using hmd_permissions = magic_enum::containers::array<feature, const char *>;
 
-extern const struct hmd_traits_t
+struct hmd_traits_t
 {
 	std::string controller_profile = "generic-trigger-squeeze";
 	const char * controller_ray_model = "assets://ray.glb";
@@ -54,7 +54,11 @@ extern const struct hmd_traits_t
 	bool discard_frame = true; // can do xrBeginFrame twice to discard the first one
 
 	XrViewConfigurationView override_view(XrViewConfigurationView) const;
-} hmd_traits;
+};
+
+const hmd_traits_t & hmd_traits();
+// must be called exactly once
+void hmd_traits_init();
 
 std::string model_name();
 

--- a/client/hardware.h
+++ b/client/hardware.h
@@ -52,7 +52,7 @@ extern const struct hmd_traits_t
 	bool hand_interaction_grip_surface = true;
 	bool pico_face_tracker = false;
 
-	XrViewConfigurationView override_view_for_hmd(XrViewConfigurationView) const;
+	XrViewConfigurationView override_view(XrViewConfigurationView) const;
 } hmd_traits;
 
 std::string model_name();

--- a/client/hardware.h
+++ b/client/hardware.h
@@ -41,7 +41,7 @@ using hmd_permissions = magic_enum::containers::array<feature, const char *>;
 struct hmd_traits_t
 {
 	std::string controller_profile = "generic-trigger-squeeze";
-	const char * controller_ray_model = "assets://ray.glb";
+	std::string controller_ray_model = "assets://ray.glb";
 	hmd_permissions permissions{};
 	XrVersion max_openxr_api_version = XR_API_VERSION_1_1;
 	uint32_t panel_width_override = 0;

--- a/client/hardware.h
+++ b/client/hardware.h
@@ -22,6 +22,7 @@
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <openxr/openxr.h>
 
@@ -54,16 +55,35 @@ enum class feature
 	body_tracking,
 };
 
+struct hmd_permissions
+{
+	const char * hand_tracking = nullptr;
+	const char * eye_gaze = nullptr;
+	const char * face_tracking = nullptr;
+	const char * body_tracking = nullptr;
+};
+
+struct hmd_traits
+{
+	const char * controller_profile = "generic-trigger-squeeze";
+	const char * controller_ray_model = "assets://ray.glb";
+	XrVersion max_openxr_api_version = XR_API_VERSION_1_1;
+	uint32_t panel_width_override = 0;
+	bool needs_srgb_conversion = true;
+	const hmd_permissions * permissions = nullptr;
+};
+
 model guess_model();
 std::string model_name();
+void initialize_runtime_hmd_traits();
+// Initialized once at startup (initialize_runtime_hmd_traits()).
+// If the HMD is recognized, returns traits specific to that model; otherwise,returns
+// default behavior.
+// Fallback: if called before initialize_runtime_hmd_traits() (avoid this!), dynamically
+// constructs itself and complains in logs.
+const hmd_traits & runtime_hmd_traits();
+const char * permission_name_for_hmd(const hmd_traits & traits, const feature f);
 
 XrViewConfigurationView override_view(XrViewConfigurationView, model = guess_model());
 
-bool need_srgb_conversion(model);
-
-// Return nullptr if no permission is required
-const char * permission_name(feature f);
-
-std::string controller_name();
-std::string controller_ray_model_name();
 std::pair<glm::vec3, glm::quat> controller_offset(std::string_view profile, xr::spaces space);

--- a/client/hmd_traits.cpp
+++ b/client/hmd_traits.cpp
@@ -17,17 +17,18 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "hardware.h"
+#include "hmd_traits.h"
 
-#include "utils/overloaded.h"
 #include "xr/to_string.h"
 
-#include <boost/pfr.hpp>
 #include <cassert>
+#include <cctype>
 #include <cstdlib>
 #include <cstring>
+#include <format>
 #include <glm/ext/quaternion_trigonometric.hpp>
 #include <limits>
+#include <optional>
 #include <string>
 
 #include <spdlog/spdlog.h>
@@ -101,24 +102,13 @@ static std::optional<bool> env_bool(std::string_view name)
 	return std::nullopt;
 }
 
-static hmd_traits_t traits;
-#ifndef NDEBUG
-static bool initialized = false;
-#endif
+hmd_traits::hmd_traits() = default;
 
-const hmd_traits_t & hmd_traits()
+void hmd_traits::init()
 {
 #ifndef NDEBUG
-	assert(initialized);
-#endif
-	return traits;
-}
-
-void hmd_traits_init()
-{
-#ifndef NDEBUG
-	assert(not initialized);
-	initialized = true;
+	assert(not initialized_);
+	initialized_ = true;
 #endif
 #ifdef __ANDROID__
 	const auto device = get_property("ro.product.device");
@@ -130,183 +120,175 @@ void hmd_traits_init()
 	spdlog::info("    ro.product.manufacturer = \"{}\":", manufacturer.value_or("<unset>"));
 	spdlog::info("    ro.product.model = \"{}\":", model.value_or("<unset>"));
 
-	traits.permissions[feature::microphone] = "android.permission.RECORD_AUDIO";
+	permissions[feature::microphone] = "android.permission.RECORD_AUDIO";
 
 	if (manufacturer == "Oculus")
 	{
-		traits.permissions[feature::eye_gaze] = "com.oculus.permission.EYE_TRACKING";
-		traits.permissions[feature::face_tracking] = "com.oculus.permission.FACE_TRACKING";
+		permissions[feature::eye_gaze] = "com.oculus.permission.EYE_TRACKING";
+		permissions[feature::face_tracking] = "com.oculus.permission.FACE_TRACKING";
 
 		// Quest hand tracking creates a fake khr/simple_controller when hand tracking
 		// is enabled, this messes with native hand tracking
-		traits.bind_simple_controller = false;
+		bind_simple_controller = false;
 
 		// Quest breaks spec and does not support grip_surface for ext/hand_interaction_ext
-		traits.hand_interaction_grip_surface = false;
+		hand_interaction_grip_surface = false;
 
 		if (device == "monterey") // Quest 1
 		{
-			traits.panel_width_override = 1440;
-			traits.controller_profile = "oculus-touch-v2";
-			traits.vk_debug_ext_allowed = false; // Quest 1 lies, the extension won't load
+			panel_width_override = 1440;
+			controller_profile = "oculus-touch-v2";
+			vk_debug_ext_allowed = false; // Quest 1 lies, the extension won't load
 		}
 		else if (device == "hollywood") // Quest 2
 		{
-			traits.panel_width_override = 1832;
-			traits.controller_profile = "oculus-touch-v3";
+			panel_width_override = 1832;
+			controller_profile = "oculus-touch-v3";
 		}
 		else if (device == "seacliff")
 		{
-			traits.panel_width_override = 1800; // Quest pro
-			traits.controller_profile = "meta-quest-touch-pro";
+			panel_width_override = 1800; // Quest pro
+			controller_profile = "meta-quest-touch-pro";
 		}
 		else if (device == "eureka")
 		{
-			traits.panel_width_override = 2064; // Quest 3
-			traits.controller_profile = "meta-quest-touch-plus";
+			panel_width_override = 2064; // Quest 3
+			controller_profile = "meta-quest-touch-plus";
 		}
 		else if (device == "panther") // Quest 3S
 		{
-			traits.panel_width_override = 1832;
-			traits.controller_profile = "meta-quest-touch-plus";
+			panel_width_override = 1832;
+			controller_profile = "meta-quest-touch-plus";
 		}
 	}
 
 	else if (model == "Lynx-R1")
 	{
-		traits.needs_srgb_conversion = false;
+		needs_srgb_conversion = false;
 	}
 
 	else if (manufacturer == "Pico")
 	{
-		traits.permissions[feature::eye_gaze] = "com.picovr.permission.EYE_TRACKING";
-		traits.permissions[feature::face_tracking] = "com.picovr.permission.FACE_TRACKING";
-		traits.view_locate = false;
-		traits.discard_frame = false;
+		permissions[feature::eye_gaze] = "com.picovr.permission.EYE_TRACKING";
+		permissions[feature::face_tracking] = "com.picovr.permission.FACE_TRACKING";
+		view_locate = false;
+		discard_frame = false;
 		const auto pico_model = get_property("pxr.vendorhw.product.model");
 		spdlog::info("    pxr.vendorhw.product.model = \"{}\":", pico_model.value_or("<unset>"));
 
 		if (pico_model == "Pico Neo 3")
 		{
-			traits.panel_width_override = 1832;
-			traits.controller_profile = "pico-neo3";
+			panel_width_override = 1832;
+			controller_profile = "pico-neo3";
 		}
 
 		else if (pico_model and pico_model->starts_with("PICO 4"))
 		{
-			traits.panel_width_override = 2160;
+			panel_width_override = 2160;
 			if (pico_model == "PICO 4 Ultra")
-				traits.controller_profile = "pico-4u";
+				controller_profile = "pico-4u";
 			else
-				traits.controller_profile = "pico-4";
+				controller_profile = "pico-4";
 
 			if (pico_model == "PICO 4 Pro" or pico_model == "PICO 4 Enterprise")
-				traits.pico_face_tracker = true;
+				pico_face_tracker = true;
 		}
 	}
 	if (manufacturer == "HTC")
 	{
 		// Accepts OpenXR 1.1 but doesn't actually implement it
-		traits.max_openxr_api_version = XR_API_VERSION_1_0;
+		max_openxr_api_version = XR_API_VERSION_1_0;
 		// Doesn't handle additive blend, so needs specific ray model
-		traits.controller_ray_model = "assets://ray-htc.glb";
+		controller_ray_model = "assets://ray-htc.glb";
 
-		traits.controller_profile = "htc-vive-focus-3";
+		controller_profile = "htc-vive-focus-3";
 
 		if (model == "VIVE Focus 3")
-			traits.panel_width_override = 2448;
+			panel_width_override = 2448;
 
 		if (model == "VIVE Focus Vision")
-			traits.panel_width_override = 2448;
+			panel_width_override = 2448;
 
 		if (model == "VIVE XR Series")
-			traits.panel_width_override = 1920;
+			panel_width_override = 1920;
 	}
 	if (manufacturer == "samsung")
 	{
 		if (model == "SM-I610") // Galaxy XR
 		{
-			traits.panel_width_override = 3552;
-			traits.controller_profile = "samsung-galaxyxr";
-			traits.permissions[feature::hand_tracking] = "android.permission.HAND_TRACKING";
-			traits.permissions[feature::eye_gaze] = "android.permission.EYE_TRACKING_FINE";
-			traits.permissions[feature::face_tracking] = "android.permission.FACE_TRACKING";
+			panel_width_override = 3552;
+			controller_profile = "samsung-galaxyxr";
+			permissions[feature::hand_tracking] = "android.permission.HAND_TRACKING";
+			permissions[feature::eye_gaze] = "android.permission.EYE_TRACKING_FINE";
+			permissions[feature::face_tracking] = "android.permission.FACE_TRACKING";
 		}
 	}
 #endif
 
 	spdlog::info("HMD traits initialized");
-	boost::pfr::for_each_field_with_name(
-	        traits,
-	        utils::overloaded{
-	                [](std::string_view name, std::string & field) {
-		                if (auto val = env_string(name))
-		                {
-			                spdlog::info("\t{} override: {} -> {}", name, field, *val);
-			                field = *val;
-		                }
-		                else
-		                {
-			                spdlog::info("\t{}: {}", name, field);
-		                }
-	                },
-	                [](std::string_view name, uint32_t & field) {
-		                if (auto val = env_u32(name))
-		                {
-			                spdlog::info("\t{} override: {} -> {}", name, field, *val);
-			                field = *val;
-		                }
-		                else
-		                {
-			                spdlog::info("\t{}: {}", name, field);
-		                }
-	                },
-	                [](std::string_view name, bool & field) {
-		                if (auto val = env_bool(name))
-		                {
-			                spdlog::info("\t{} override: {} -> {}", name, field, *val);
-			                field = *val;
-		                }
-		                else
-		                {
-			                spdlog::info("\t{}: {}", name, field);
-		                }
-	                },
-	                [](std::string_view name, XrVersion & field) {
-		                if (auto val = env_string(name))
-		                {
-			                XrVersion v;
-			                if (val == "1.1")
-				                v = XR_API_VERSION_1_1;
-			                else if (val == "1.0")
-				                v = XR_API_VERSION_1_0;
-			                else
-			                {
-				                spdlog::warn("XrVersion {} not recognized", *val);
-				                return;
-			                }
-			                spdlog::info("\t{} override: {} -> {}", name, xr::to_string(field), xr::to_string(v));
-			                field = v;
-		                }
-		                else
-		                {
-			                spdlog::info("\t{}: {}", name, xr::to_string(field));
-		                }
-	                },
-	                [](std::string_view name, hmd_permissions &) {
-	                }});
-};
+	auto log_string = [](std::string_view name, std::string & field) {
+		if (auto val = env_string(name))
+		{
+			spdlog::info("\t{} override: {} -> {}", name, field, *val);
+			field = *val;
+		}
+		else
+		{
+			spdlog::info("\t{}: {}", name, field);
+		}
+	};
+	auto log_u32 = [](std::string_view name, uint32_t & field) {
+		if (auto val = env_u32(name))
+		{
+			spdlog::info("\t{} override: {} -> {}", name, field, *val);
+			field = *val;
+		}
+		else
+		{
+			spdlog::info("\t{}: {}", name, field);
+		}
+	};
+	auto log_bool = [](std::string_view name, bool & field) {
+		if (auto val = env_bool(name))
+		{
+			spdlog::info("\t{} override: {} -> {}", name, field, *val);
+			field = *val;
+		}
+		else
+		{
+			spdlog::info("\t{}: {}", name, field);
+		}
+	};
 
-std::string model_name()
-{
-#ifdef __ANDROID__
-	const auto manufacturer = get_property("ro.product.manufacturer").value_or("");
-	const auto model = get_property("ro.product.model").value_or("");
-
-	return manufacturer + " " + model;
-#else
-	return "Unknown headset";
-#endif
+	log_string("controller_profile", controller_profile);
+	log_string("controller_ray_model", controller_ray_model);
+	if (auto val = env_string("max_openxr_api_version"))
+	{
+		XrVersion v;
+		if (val == "1.1")
+			v = XR_API_VERSION_1_1;
+		else if (val == "1.0")
+			v = XR_API_VERSION_1_0;
+		else
+		{
+			spdlog::warn("XrVersion {} not recognized", *val);
+			v = max_openxr_api_version;
+		}
+		spdlog::info("\t{} override: {} -> {}", "max_openxr_api_version", xr::to_string(max_openxr_api_version), xr::to_string(v));
+		max_openxr_api_version = v;
+	}
+	else
+	{
+		spdlog::info("\t{}: {}", "max_openxr_api_version", xr::to_string(max_openxr_api_version));
+	}
+	log_u32("panel_width_override", panel_width_override);
+	log_bool("needs_srgb_conversion", needs_srgb_conversion);
+	log_bool("view_locate", view_locate);
+	log_bool("vk_debug_ext_allowed", vk_debug_ext_allowed);
+	log_bool("bind_simple_controller", bind_simple_controller);
+	log_bool("hand_interaction_grip_surface", hand_interaction_grip_surface);
+	log_bool("pico_face_tracker", pico_face_tracker);
+	log_bool("discard_frame", discard_frame);
 }
 
 static XrViewConfigurationView scale_view(XrViewConfigurationView view, uint32_t width)
@@ -318,7 +300,19 @@ static XrViewConfigurationView scale_view(XrViewConfigurationView view, uint32_t
 	return view;
 }
 
-XrViewConfigurationView hmd_traits_t::override_view(XrViewConfigurationView view) const
+std::string hmd_traits::model_name() const
+{
+#ifdef __ANDROID__
+	const auto manufacturer = get_property("ro.product.manufacturer").value_or("");
+	const auto model = get_property("ro.product.model").value_or("");
+
+	return manufacturer + " " + model;
+#else
+	return "Unknown headset";
+#endif
+}
+
+XrViewConfigurationView hmd_traits::override_view(XrViewConfigurationView view) const
 {
 	// Standalone headsets tend to report a lower resolution
 	// as the GPU can't handle full res.
@@ -329,7 +323,7 @@ XrViewConfigurationView hmd_traits_t::override_view(XrViewConfigurationView view
 	return view;
 }
 
-std::pair<glm::vec3, glm::quat> controller_offset(std::string_view profile, xr::spaces space)
+std::pair<glm::vec3, glm::quat> hmd_traits::controller_offset(xr::spaces space) const
 {
 #ifndef __ANDROID__
 	if (const char * offset = [space]() -> const char * {
@@ -359,6 +353,8 @@ std::pair<glm::vec3, glm::quat> controller_offset(std::string_view profile, xr::
 	}
 #endif
 
+	std::string_view profile = controller_profile;
+
 	if (profile == "oculus-touch-v2")
 		switch (space)
 		{
@@ -381,62 +377,122 @@ std::pair<glm::vec3, glm::quat> controller_offset(std::string_view profile, xr::
 		{
 			case xr::spaces::grip_left:
 			case xr::spaces::grip_right:
-				return {{0, -0.010, -0.025}, glm::angleAxis(glm::radians(-12.f), glm::vec3{1, 0, 0})};
+				return {{0, -0.006, -0.025}, glm::angleAxis(glm::radians(-14.f), glm::vec3{1, 0, 0})};
+
+			case xr::spaces::aim_left:
+				return {{-0.010, 0, 0.02}, {1, 0, 0, 0}};
+
+			case xr::spaces::aim_right:
+				return {{0.010, 0, 0.02}, {1, 0, 0, 0}};
+
+			default:
+				break;
+		}
+	}
+	else if (profile == "meta-quest-touch-pro")
+	{
+		switch (space)
+		{
+			case xr::spaces::grip_left:
+			case xr::spaces::grip_right:
+				return {{0, 0, 0}, glm::angleAxis(glm::radians(-20.f), glm::vec3{1, 0, 0})};
+
+			case xr::spaces::aim_left:
+				return {{0, 0, 0}, {1, 0, 0, 0}};
+
+			case xr::spaces::aim_right:
+				return {{0, 0, 0}, {1, 0, 0, 0}};
+
+			default:
+				break;
+		}
+	}
+	else if (profile == "oculus-touch-v3")
+	{
+		switch (space)
+		{
+			case xr::spaces::grip_left:
+			case xr::spaces::grip_right:
+				return {{0, -0.003, -0.047}, glm::angleAxis(glm::radians(-20.f), glm::vec3{1, 0, 0})};
+
+			case xr::spaces::aim_left:
+				return {{-0.006, 0, 0.015}, {1, 0, 0, 0}};
+
+			case xr::spaces::aim_right:
+				return {{0.006, 0, 0.015}, {1, 0, 0, 0}};
+
+			default:
+				break;
+		}
+	}
+	else if (profile == "pico-neo3")
+	{
+		switch (space)
+		{
+			case xr::spaces::grip_left:
+			case xr::spaces::grip_right:
+				return {{0, -0.016, -0.05}, glm::angleAxis(glm::radians(-15.f), glm::vec3{1, 0, 0})};
 
 			case xr::spaces::aim_left:
 			case xr::spaces::aim_right:
-				return {{0, 0, -0.03}, {1, 0, 0, 0}};
+				return {{0, 0, 0}, {1, 0, 0, 0}};
+
+			default:
+				break;
+		}
+	}
+	else if (profile == "pico-4" or profile == "pico-4u")
+	{
+		switch (space)
+		{
+			case xr::spaces::grip_left:
+			case xr::spaces::grip_right:
+				return {{0, -0.01, -0.04}, glm::angleAxis(glm::radians(-20.f), glm::vec3{1, 0, 0})};
+
+			case xr::spaces::aim_left:
+				return {{-0.005, 0, 0.02}, {1, 0, 0, 0}};
+
+			case xr::spaces::aim_right:
+				return {{0.005, 0, 0.02}, {1, 0, 0, 0}};
 
 			default:
 				break;
 		}
 	}
 	else if (profile == "htc-vive-focus-3")
+	{
 		switch (space)
 		{
 			case xr::spaces::grip_left:
 			case xr::spaces::grip_right:
-				return {{0, 0.007, -0.030}, {1, 0, 0, 0}};
+				return {{0, 0, -0.03}, glm::angleAxis(glm::radians(-35.f), glm::vec3{1, 0, 0})};
 
 			case xr::spaces::aim_left:
 			case xr::spaces::aim_right:
-				return {{0, -0.025, 0.005}, {1, 0, 0, 0}};
+				return {{0, 0, 0}, {1, 0, 0, 0}};
 
 			default:
 				break;
 		}
-	else if (profile == "pico-4" || profile == "pico-4s")
-		switch (space)
-		{
-			case xr::spaces::grip_left:
-			case xr::spaces::grip_right:
-				return {{0, -0.014, -0.048}, glm::angleAxis(glm::radians(-35.060f), glm::vec3{1, 0, 0})};
-
-			default:
-				break;
-		}
-
-	else if (profile == "pico-neo3")
-		switch (space)
-		{
-			case xr::spaces::grip_left:
-			case xr::spaces::grip_right:
-				return {{0, 0.005, -0.051}, glm::angleAxis(glm::radians(-29.400f), glm::vec3{1, 0, 0})};
-
-			default:
-				break;
-		}
-
+	}
 	else if (profile == "samsung-galaxyxr")
+	{
 		switch (space)
 		{
 			case xr::spaces::grip_left:
-				return {{-0.005, 0.000, 0.035}, {1, 0, 0, 0}};
 			case xr::spaces::grip_right:
-				return {{0.005, 0.000, 0.035}, {1, 0, 0, 0}};
+				return {{0, -0.01, -0.02}, glm::angleAxis(glm::radians(-20.f), glm::vec3{1, 0, 0})};
+
+			case xr::spaces::aim_left:
+				return {{-0.003, 0, 0.028}, {1, 0, 0, 0}};
+
+			case xr::spaces::aim_right:
+				return {{0.003, 0, 0.028}, {1, 0, 0, 0}};
+
 			default:
 				break;
 		}
+	}
 
 	return {{0, 0, 0}, {1, 0, 0, 0}};
 }

--- a/client/hmd_traits.h
+++ b/client/hmd_traits.h
@@ -1,7 +1,7 @@
 /*
  * WiVRn VR streaming
- * Copyright (C) 2023  Guillaume Meunier <guillaume.meunier@centraliens.net>
- * Copyright (C) 2023  Patrick Nicolas <patricknicolas@laposte.net>
+ * Copyright (C) 2026  Guillaume Meunier <guillaume.meunier@centraliens.net>
+ * Copyright (C) 2026  Patrick Nicolas <patricknicolas@laposte.net>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,30 +16,23 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #pragma once
 
+#include "configuration.h"
 #include "xr/space.h"
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
 #include <magic_enum_containers.hpp>
 #include <string>
-#include <string_view>
 #include <utility>
 #include <openxr/openxr.h>
 
-enum class feature
-{
-	microphone,
-	hand_tracking,
-	eye_gaze,
-	face_tracking,
-	body_tracking,
-};
-
 using hmd_permissions = magic_enum::containers::array<feature, const char *>;
 
-struct hmd_traits_t
+class hmd_traits
 {
+public:
 	std::string controller_profile = "generic-trigger-squeeze";
 	std::string controller_ray_model = "assets://ray.glb";
 	hmd_permissions permissions{};
@@ -52,14 +45,31 @@ struct hmd_traits_t
 	bool hand_interaction_grip_surface = true;
 	bool pico_face_tracker = false;
 	bool discard_frame = true; // can do xrBeginFrame twice to discard the first one
+#ifndef NDEBUG
+private:
+	bool initialized_ = false;
+#endif
 
+public:
+	hmd_traits();
+
+	void init();
+
+	const char * permission_name(feature f) const
+	{
+		return permissions[f];
+	}
+
+	std::string model_name() const;
+	std::pair<glm::vec3, glm::quat> controller_offset(xr::spaces space) const;
 	XrViewConfigurationView override_view(XrViewConfigurationView) const;
+
+	bool is_initialized() const
+	{
+#ifndef NDEBUG
+		return initialized_;
+#else
+		return true;
+#endif
+	}
 };
-
-const hmd_traits_t & hmd_traits();
-// must be called exactly once
-void hmd_traits_init();
-
-std::string model_name();
-
-std::pair<glm::vec3, glm::quat> controller_offset(std::string_view profile, xr::spaces space);

--- a/client/scenes/input_profile.cpp
+++ b/client/scenes/input_profile.cpp
@@ -306,7 +306,7 @@ input_profile::input_profile(scene & scene, const std::filesystem::path & json_p
 		else
 			continue;
 
-		auto && [ray_entity, ray_node] = scene.add_gltf(controller_ray_model_name(), layer_mask_ray);
+		auto && [ray_entity, ray_node] = scene.add_gltf(runtime_hmd_traits().controller_ray_model, layer_mask_ray);
 
 		ray_node.name = (std::string)layout.key + "_ray";
 		spdlog::debug("Created entity {}", ray_node.name);

--- a/client/scenes/input_profile.cpp
+++ b/client/scenes/input_profile.cpp
@@ -306,7 +306,7 @@ input_profile::input_profile(scene & scene, const std::filesystem::path & json_p
 		else
 			continue;
 
-		auto && [ray_entity, ray_node] = scene.add_gltf(runtime_hmd_traits().controller_ray_model, layer_mask_ray);
+		auto && [ray_entity, ray_node] = scene.add_gltf(hmd_traits.controller_ray_model, layer_mask_ray);
 
 		ray_node.name = (std::string)layout.key + "_ray";
 		spdlog::debug("Created entity {}", ray_node.name);

--- a/client/scenes/input_profile.cpp
+++ b/client/scenes/input_profile.cpp
@@ -306,7 +306,7 @@ input_profile::input_profile(scene & scene, const std::filesystem::path & json_p
 		else
 			continue;
 
-		auto && [ray_entity, ray_node] = scene.add_gltf(hmd_traits.controller_ray_model, layer_mask_ray);
+		auto && [ray_entity, ray_node] = scene.add_gltf(hmd_traits().controller_ray_model, layer_mask_ray);
 
 		ray_node.name = (std::string)layout.key + "_ray";
 		spdlog::debug("Created entity {}", ray_node.name);

--- a/client/scenes/input_profile.cpp
+++ b/client/scenes/input_profile.cpp
@@ -19,7 +19,6 @@
 #include "input_profile.h"
 
 #include "application.h"
-#include "hardware.h"
 #include "render/scene_components.h"
 #include "utils/mapped_file.h"
 #include "xr/space.h"
@@ -306,7 +305,7 @@ input_profile::input_profile(scene & scene, const std::filesystem::path & json_p
 		else
 			continue;
 
-		auto && [ray_entity, ray_node] = scene.add_gltf(hmd_traits().controller_ray_model, layer_mask_ray);
+		auto && [ray_entity, ray_node] = scene.add_gltf(application::get_hmd_traits().controller_ray_model, layer_mask_ray);
 
 		ray_node.name = (std::string)layout.key + "_ray";
 		spdlog::debug("Created entity {}", ray_node.name);

--- a/client/scenes/lobby.cpp
+++ b/client/scenes/lobby.cpp
@@ -1114,7 +1114,7 @@ void scenes::lobby::on_focused()
 
 	auto views = system.view_configuration_views(viewconfig);
 	assert(views.size() == 2); // FIXME
-	stream_view = override_view(views[0], guess_model());
+	stream_view = override_view_for_hmd(runtime_hmd_traits(), views[0]);
 	width = views[0].recommendedImageRectWidth;
 	height = views[0].recommendedImageRectHeight;
 

--- a/client/scenes/lobby.cpp
+++ b/client/scenes/lobby.cpp
@@ -23,7 +23,6 @@
 #include "constants.h"
 #include "glm/geometric.hpp"
 #include "hand_model.h"
-#include "hardware.h"
 #include "imgui.h"
 #include "openxr/openxr.h"
 #include "protocol_version.h"
@@ -1114,7 +1113,7 @@ void scenes::lobby::on_focused()
 
 	auto views = system.view_configuration_views(viewconfig);
 	assert(views.size() == 2); // FIXME
-	stream_view = hmd_traits().override_view(views[0]);
+	stream_view = application::get_hmd_traits().override_view(views[0]);
 	width = views[0].recommendedImageRectWidth;
 	height = views[0].recommendedImageRectHeight;
 
@@ -1135,7 +1134,7 @@ void scenes::lobby::on_focused()
 		config.save();
 	}
 
-	const auto & profile = hmd_traits().controller_profile;
+	const auto & profile = application::get_hmd_traits().controller_profile;
 	input.emplace(
 	        *this,
 	        "assets://controllers/" + profile + "/profile.json",
@@ -1148,7 +1147,7 @@ void scenes::lobby::on_focused()
 
 	for (auto i: {xr::spaces::aim_left, xr::spaces::aim_right, xr::spaces::grip_left, xr::spaces::grip_right})
 	{
-		auto [p, q] = input->offset[i] = controller_offset(profile, i);
+		auto [p, q] = input->offset[i] = application::get_hmd_traits().controller_offset(i);
 
 		auto rot = glm::degrees(glm::eulerAngles(q));
 		spdlog::info("Initializing offset of space {} to ({}, {}, {}) mm, ({}, {}, {})°",

--- a/client/scenes/lobby.cpp
+++ b/client/scenes/lobby.cpp
@@ -1135,10 +1135,10 @@ void scenes::lobby::on_focused()
 		config.save();
 	}
 
-	std::string profile = controller_name();
+	const std::string_view profile = runtime_hmd_traits().controller_profile;
 	input.emplace(
 	        *this,
-	        "assets://controllers/" + profile + "/profile.json",
+	        "assets://controllers/" + std::string(profile) + "/profile.json",
 	        layer_controllers,
 	        layer_rays,
 	        get_action("left_trigger").first,
@@ -1148,7 +1148,7 @@ void scenes::lobby::on_focused()
 
 	for (auto i: {xr::spaces::aim_left, xr::spaces::aim_right, xr::spaces::grip_left, xr::spaces::grip_right})
 	{
-		auto [p, q] = input->offset[i] = controller_offset(controller_name(), i);
+		auto [p, q] = input->offset[i] = controller_offset(profile, i);
 
 		auto rot = glm::degrees(glm::eulerAngles(q));
 		spdlog::info("Initializing offset of space {} to ({}, {}, {}) mm, ({}, {}, {})°",

--- a/client/scenes/lobby.cpp
+++ b/client/scenes/lobby.cpp
@@ -1114,7 +1114,7 @@ void scenes::lobby::on_focused()
 
 	auto views = system.view_configuration_views(viewconfig);
 	assert(views.size() == 2); // FIXME
-	stream_view = hmd_traits.override_view(views[0]);
+	stream_view = hmd_traits().override_view(views[0]);
 	width = views[0].recommendedImageRectWidth;
 	height = views[0].recommendedImageRectHeight;
 
@@ -1135,7 +1135,7 @@ void scenes::lobby::on_focused()
 		config.save();
 	}
 
-	const auto & profile = hmd_traits.controller_profile;
+	const auto & profile = hmd_traits().controller_profile;
 	input.emplace(
 	        *this,
 	        "assets://controllers/" + profile + "/profile.json",

--- a/client/scenes/lobby.cpp
+++ b/client/scenes/lobby.cpp
@@ -1114,7 +1114,7 @@ void scenes::lobby::on_focused()
 
 	auto views = system.view_configuration_views(viewconfig);
 	assert(views.size() == 2); // FIXME
-	stream_view = hmd_traits.override_view_for_hmd(views[0]);
+	stream_view = hmd_traits.override_view(views[0]);
 	width = views[0].recommendedImageRectWidth;
 	height = views[0].recommendedImageRectHeight;
 

--- a/client/scenes/lobby.cpp
+++ b/client/scenes/lobby.cpp
@@ -1114,7 +1114,7 @@ void scenes::lobby::on_focused()
 
 	auto views = system.view_configuration_views(viewconfig);
 	assert(views.size() == 2); // FIXME
-	stream_view = override_view_for_hmd(runtime_hmd_traits(), views[0]);
+	stream_view = hmd_traits.override_view_for_hmd(views[0]);
 	width = views[0].recommendedImageRectWidth;
 	height = views[0].recommendedImageRectHeight;
 
@@ -1135,10 +1135,10 @@ void scenes::lobby::on_focused()
 		config.save();
 	}
 
-	const std::string_view profile = runtime_hmd_traits().controller_profile;
+	const auto & profile = hmd_traits.controller_profile;
 	input.emplace(
 	        *this,
-	        "assets://controllers/" + std::string(profile) + "/profile.json",
+	        "assets://controllers/" + profile + "/profile.json",
 	        layer_controllers,
 	        layer_rays,
 	        get_action("left_trigger").first,

--- a/client/scenes/stream.cpp
+++ b/client/scenes/stream.cpp
@@ -217,7 +217,7 @@ std::shared_ptr<scenes::stream> scenes::stream::create(std::unique_ptr<wivrn_ses
 
 		{
 			auto view = self->system.view_configuration_views(self->viewconfig)[0];
-			view = override_view_for_hmd(runtime_hmd_traits(), view);
+			view = hmd_traits.override_view_for_hmd(view);
 
 			info.render_eye_width = view.recommendedImageRectWidth * config.resolution_scale;
 			info.render_eye_height = view.recommendedImageRectHeight * config.resolution_scale;
@@ -421,10 +421,10 @@ void scenes::stream::on_focused()
 {
 	gui_status_last_change = instance.now();
 
-	const std::string_view profile = runtime_hmd_traits().controller_profile;
+	const auto & profile = hmd_traits.controller_profile;
 	input.emplace(
 	        *this,
-	        "assets://controllers/" + std::string(profile) + "/profile.json",
+	        "assets://controllers/" + profile + "/profile.json",
 	        layer_controllers,
 	        layer_rays,
 	        get_action("left_trigger").first,
@@ -684,41 +684,34 @@ void scenes::stream::update_gui_position(xr::spaces controller)
 {
 	std::optional<std::pair<glm::vec3, glm::quat>> aim;
 
-	switch (guess_model())
+	if (hmd_traits.view_locate)
 	{
-		case model::pico_4:
-		case model::pico_4s:
-		case model::pico_4_pro:
-		case model::pico_4_enterprise: {
-			// Pico fails to find its controllers within view space, so use the head position in
-			// world space as a reference
-			aim = application::locate_controller(
-			        application::space(controller),
-			        application::space(xr::spaces::world),
-			        predicted_display_time);
-
-			auto head_position = application::locate_controller(application::space(xr::spaces::view),
-			                                                    application::space(xr::spaces::world),
-			                                                    predicted_display_time);
-			if (not aim || not head_position)
-				return;
-
-			aim->first = glm::conjugate(head_position->second) * (aim->first - head_position->first);
-			aim->second = glm::conjugate(head_position->second) * aim->second;
-
-			break;
-		}
-		default:
-			aim = application::locate_controller(
-			        application::space(controller),
-			        application::space(xr::spaces::view),
-			        predicted_display_time);
-
-			if (not aim)
-				return;
-
-			break;
+		aim = application::locate_controller(
+		        application::space(controller),
+		        application::space(xr::spaces::view),
+		        predicted_display_time);
 	}
+	else
+	{
+		// Pico fails to find its controllers within view space, so use the head position in
+		// world space as a reference
+		aim = application::locate_controller(
+		        application::space(controller),
+		        application::space(xr::spaces::world),
+		        predicted_display_time);
+
+		auto head_position = application::locate_controller(application::space(xr::spaces::view),
+		                                                    application::space(xr::spaces::world),
+		                                                    predicted_display_time);
+		if (not(aim and head_position))
+			return;
+
+		aim->first = glm::conjugate(head_position->second) * (aim->first - head_position->first);
+		aim->second = glm::conjugate(head_position->second) * aim->second;
+	}
+
+	if (not aim)
+		return;
 
 	auto [offset_position, offset_orientation] = input->offset[controller];
 

--- a/client/scenes/stream.cpp
+++ b/client/scenes/stream.cpp
@@ -934,7 +934,8 @@ void scenes::stream::render(const XrFrameState & frame_state)
 	}
 
 	// Allow the headset to time warp if we are redisplaying a frame
-	if (std::ranges::any_of(current_blit_handles, [](const auto & h) { return h and h->feedback.times_displayed < 2; }) or
+	if ((not hmd_traits.discard_frame) or
+	    std::ranges::any_of(current_blit_handles, [](const auto & h) { return h and h->feedback.times_displayed < 2; }) or
 	    is_gui_interactable())
 	{
 		XrExtent2Di extents[view_count];

--- a/client/scenes/stream.cpp
+++ b/client/scenes/stream.cpp
@@ -33,7 +33,6 @@
 #include "audio/audio.h"
 #include "boost/pfr/core.hpp"
 #include "decoder/shard_accumulator.h"
-#include "hardware.h"
 #include "inplace_vector.hpp"
 #include "spdlog/spdlog.h"
 #include "utils/named_thread.h"
@@ -217,7 +216,7 @@ std::shared_ptr<scenes::stream> scenes::stream::create(std::unique_ptr<wivrn_ses
 
 		{
 			auto view = self->system.view_configuration_views(self->viewconfig)[0];
-			view = hmd_traits().override_view(view);
+			view = application::get_hmd_traits().override_view(view);
 
 			info.render_eye_width = view.recommendedImageRectWidth * config.resolution_scale;
 			info.render_eye_height = view.recommendedImageRectHeight * config.resolution_scale;
@@ -421,7 +420,7 @@ void scenes::stream::on_focused()
 {
 	gui_status_last_change = instance.now();
 
-	const auto & profile = hmd_traits().controller_profile;
+	const auto & profile = application::get_hmd_traits().controller_profile;
 	input.emplace(
 	        *this,
 	        "assets://controllers/" + profile + "/profile.json",
@@ -434,7 +433,7 @@ void scenes::stream::on_focused()
 
 	for (auto i: {xr::spaces::aim_left, xr::spaces::aim_right, xr::spaces::grip_left, xr::spaces::grip_right})
 	{
-		auto [p, q] = input->offset[i] = controller_offset(profile, i);
+		auto [p, q] = input->offset[i] = application::get_hmd_traits().controller_offset(i);
 
 		auto rot = glm::degrees(glm::eulerAngles(q));
 		spdlog::info("Initializing offset of space {} to ({}, {}, {}) mm, ({}, {}, {})°",
@@ -684,7 +683,7 @@ void scenes::stream::update_gui_position(xr::spaces controller)
 {
 	std::optional<std::pair<glm::vec3, glm::quat>> aim;
 
-	if (hmd_traits().view_locate)
+	if (application::get_hmd_traits().view_locate)
 	{
 		aim = application::locate_controller(
 		        application::space(controller),
@@ -934,7 +933,7 @@ void scenes::stream::render(const XrFrameState & frame_state)
 	}
 
 	// Allow the headset to time warp if we are redisplaying a frame
-	if ((not hmd_traits().discard_frame) or
+	if ((not application::get_hmd_traits().discard_frame) or
 	    std::ranges::any_of(current_blit_handles, [](const auto & h) { return h and h->feedback.times_displayed < 2; }) or
 	    is_gui_interactable())
 	{

--- a/client/scenes/stream.cpp
+++ b/client/scenes/stream.cpp
@@ -217,7 +217,7 @@ std::shared_ptr<scenes::stream> scenes::stream::create(std::unique_ptr<wivrn_ses
 
 		{
 			auto view = self->system.view_configuration_views(self->viewconfig)[0];
-			view = hmd_traits.override_view(view);
+			view = hmd_traits().override_view(view);
 
 			info.render_eye_width = view.recommendedImageRectWidth * config.resolution_scale;
 			info.render_eye_height = view.recommendedImageRectHeight * config.resolution_scale;
@@ -421,7 +421,7 @@ void scenes::stream::on_focused()
 {
 	gui_status_last_change = instance.now();
 
-	const auto & profile = hmd_traits.controller_profile;
+	const auto & profile = hmd_traits().controller_profile;
 	input.emplace(
 	        *this,
 	        "assets://controllers/" + profile + "/profile.json",
@@ -684,7 +684,7 @@ void scenes::stream::update_gui_position(xr::spaces controller)
 {
 	std::optional<std::pair<glm::vec3, glm::quat>> aim;
 
-	if (hmd_traits.view_locate)
+	if (hmd_traits().view_locate)
 	{
 		aim = application::locate_controller(
 		        application::space(controller),
@@ -934,7 +934,7 @@ void scenes::stream::render(const XrFrameState & frame_state)
 	}
 
 	// Allow the headset to time warp if we are redisplaying a frame
-	if ((not hmd_traits.discard_frame) or
+	if ((not hmd_traits().discard_frame) or
 	    std::ranges::any_of(current_blit_handles, [](const auto & h) { return h and h->feedback.times_displayed < 2; }) or
 	    is_gui_interactable())
 	{

--- a/client/scenes/stream.cpp
+++ b/client/scenes/stream.cpp
@@ -217,7 +217,7 @@ std::shared_ptr<scenes::stream> scenes::stream::create(std::unique_ptr<wivrn_ses
 
 		{
 			auto view = self->system.view_configuration_views(self->viewconfig)[0];
-			view = override_view(view, guess_model());
+			view = override_view_for_hmd(runtime_hmd_traits(), view);
 
 			info.render_eye_width = view.recommendedImageRectWidth * config.resolution_scale;
 			info.render_eye_height = view.recommendedImageRectHeight * config.resolution_scale;

--- a/client/scenes/stream.cpp
+++ b/client/scenes/stream.cpp
@@ -421,10 +421,10 @@ void scenes::stream::on_focused()
 {
 	gui_status_last_change = instance.now();
 
-	std::string profile = controller_name();
+	const std::string_view profile = runtime_hmd_traits().controller_profile;
 	input.emplace(
 	        *this,
-	        "assets://controllers/" + profile + "/profile.json",
+	        "assets://controllers/" + std::string(profile) + "/profile.json",
 	        layer_controllers,
 	        layer_rays,
 	        get_action("left_trigger").first,
@@ -434,7 +434,7 @@ void scenes::stream::on_focused()
 
 	for (auto i: {xr::spaces::aim_left, xr::spaces::aim_right, xr::spaces::grip_left, xr::spaces::grip_right})
 	{
-		auto [p, q] = input->offset[i] = controller_offset(controller_name(), i);
+		auto [p, q] = input->offset[i] = controller_offset(profile, i);
 
 		auto rot = glm::degrees(glm::eulerAngles(q));
 		spdlog::info("Initializing offset of space {} to ({}, {}, {}) mm, ({}, {}, {})°",

--- a/client/scenes/stream.cpp
+++ b/client/scenes/stream.cpp
@@ -217,7 +217,7 @@ std::shared_ptr<scenes::stream> scenes::stream::create(std::unique_ptr<wivrn_ses
 
 		{
 			auto view = self->system.view_configuration_views(self->viewconfig)[0];
-			view = hmd_traits.override_view_for_hmd(view);
+			view = hmd_traits.override_view(view);
 
 			info.render_eye_width = view.recommendedImageRectWidth * config.resolution_scale;
 			info.render_eye_height = view.recommendedImageRectHeight * config.resolution_scale;

--- a/client/scenes/stream_defoveator.cpp
+++ b/client/scenes/stream_defoveator.cpp
@@ -127,7 +127,7 @@ stream_defoveator::pipeline_t & stream_defoveator::ensure_pipeline(size_t view, 
 	// Fragment shader
 	auto specialization = make_specialization_constants(
 	        int32_t(alpha),
-	        VkBool32(need_srgb_conversion(guess_model())));
+	        VkBool32(runtime_hmd_traits().needs_srgb_conversion));
 	auto fragment_shader = load_shader(device, "reprojection.frag");
 
 	vk::pipeline_builder pipeline_info{

--- a/client/scenes/stream_defoveator.cpp
+++ b/client/scenes/stream_defoveator.cpp
@@ -127,7 +127,7 @@ stream_defoveator::pipeline_t & stream_defoveator::ensure_pipeline(size_t view, 
 	// Fragment shader
 	auto specialization = make_specialization_constants(
 	        int32_t(alpha),
-	        VkBool32(runtime_hmd_traits().needs_srgb_conversion));
+	        VkBool32(hmd_traits.needs_srgb_conversion));
 	auto fragment_shader = load_shader(device, "reprojection.frag");
 
 	vk::pipeline_builder pipeline_info{

--- a/client/scenes/stream_defoveator.cpp
+++ b/client/scenes/stream_defoveator.cpp
@@ -127,7 +127,7 @@ stream_defoveator::pipeline_t & stream_defoveator::ensure_pipeline(size_t view, 
 	// Fragment shader
 	auto specialization = make_specialization_constants(
 	        int32_t(alpha),
-	        VkBool32(hmd_traits().needs_srgb_conversion));
+	        VkBool32(application::get_hmd_traits().needs_srgb_conversion));
 	auto fragment_shader = load_shader(device, "reprojection.frag");
 
 	vk::pipeline_builder pipeline_info{

--- a/client/scenes/stream_defoveator.cpp
+++ b/client/scenes/stream_defoveator.cpp
@@ -127,7 +127,7 @@ stream_defoveator::pipeline_t & stream_defoveator::ensure_pipeline(size_t view, 
 	// Fragment shader
 	auto specialization = make_specialization_constants(
 	        int32_t(alpha),
-	        VkBool32(hmd_traits.needs_srgb_conversion));
+	        VkBool32(hmd_traits().needs_srgb_conversion));
 	auto fragment_shader = load_shader(device, "reprojection.frag");
 
 	vk::pipeline_builder pipeline_info{

--- a/client/scenes/stream_tracking.cpp
+++ b/client/scenes/stream_tracking.cpp
@@ -493,7 +493,7 @@ void scenes::stream::tracking()
 							break;
 						case wivrn::device_id::EYE_GAZE:
 							// Eye gaze uses view pose as the origin
-							if (hmd_traits.view_locate)
+							if (hmd_traits().view_locate)
 								tracking.device_poses.push_back(locate_space(item.device, spaces[item.device], spaces[wivrn::device_id::HEAD], tracking.timestamp));
 							else
 							{
@@ -754,7 +754,7 @@ void scenes::stream::send_derived_pose()
 		{
 			// This may happen if the runtime does not support palm ext
 			// check if we have a device specific offset
-			if (not hmd_traits.hand_interaction_grip_surface)
+			if (not hmd_traits().hand_interaction_grip_surface)
 			{
 				switch (target)
 				{

--- a/client/scenes/stream_tracking.cpp
+++ b/client/scenes/stream_tracking.cpp
@@ -493,7 +493,7 @@ void scenes::stream::tracking()
 							break;
 						case wivrn::device_id::EYE_GAZE:
 							// Eye gaze uses view pose as the origin
-							if (hmd_traits().view_locate)
+							if (application::get_hmd_traits().view_locate)
 								tracking.device_poses.push_back(locate_space(item.device, spaces[item.device], spaces[wivrn::device_id::HEAD], tracking.timestamp));
 							else
 							{
@@ -754,7 +754,7 @@ void scenes::stream::send_derived_pose()
 		{
 			// This may happen if the runtime does not support palm ext
 			// check if we have a device specific offset
-			if (not hmd_traits().hand_interaction_grip_surface)
+			if (not application::get_hmd_traits().hand_interaction_grip_surface)
 			{
 				switch (target)
 				{

--- a/client/scenes/stream_tracking.cpp
+++ b/client/scenes/stream_tracking.cpp
@@ -493,36 +493,31 @@ void scenes::stream::tracking()
 							break;
 						case wivrn::device_id::EYE_GAZE:
 							// Eye gaze uses view pose as the origin
-							switch (guess_model())
+							if (hmd_traits.view_locate)
+								tracking.device_poses.push_back(locate_space(item.device, spaces[item.device], spaces[wivrn::device_id::HEAD], tracking.timestamp));
+							else
 							{
-								case model::pico_4_pro:
-								case model::pico_4_enterprise: {
-									// Pico headsets fail to locate gaze relative to view
-									auto gaze = locate_space(item.device, spaces[item.device], world_space, tracking.timestamp);
-									auto view_pose = locate_space(item.device, view_space, world_space, tracking.timestamp);
-									glm::quat gaze_quat(gaze.pose.orientation.w, gaze.pose.orientation.x, gaze.pose.orientation.y, gaze.pose.orientation.z);
-									glm::quat view_quat(view_pose.pose.orientation.w, view_pose.pose.orientation.x, view_pose.pose.orientation.y, view_pose.pose.orientation.z);
-									gaze_quat = glm::conjugate(view_quat) * gaze_quat;
-									using flags = from_headset::tracking::flags;
-									tracking.device_poses.push_back(
-									        from_headset::tracking::pose{
-									                // Zero position and velocities
-									                .pose = {
-									                        .orientation = {
-									                                .x = gaze_quat.x,
-									                                .y = gaze_quat.y,
-									                                .z = gaze_quat.z,
-									                                .w = gaze_quat.w,
-									                        },
-									                },
-									                .device = item.device,
-									                .flags = uint8_t(gaze.flags & view_pose.flags & ~(flags::linear_velocity_valid | flags::angular_velocity_valid)),
-									        });
-								}
-								break;
-								default:
-									tracking.device_poses.push_back(locate_space(item.device, spaces[item.device], spaces[wivrn::device_id::HEAD], tracking.timestamp));
-									break;
+								// Pico headsets fail to locate gaze relative to view
+								auto gaze = locate_space(item.device, spaces[item.device], world_space, tracking.timestamp);
+								auto view_pose = locate_space(item.device, view_space, world_space, tracking.timestamp);
+								glm::quat gaze_quat(gaze.pose.orientation.w, gaze.pose.orientation.x, gaze.pose.orientation.y, gaze.pose.orientation.z);
+								glm::quat view_quat(view_pose.pose.orientation.w, view_pose.pose.orientation.x, view_pose.pose.orientation.y, view_pose.pose.orientation.z);
+								gaze_quat = glm::conjugate(view_quat) * gaze_quat;
+								using flags = from_headset::tracking::flags;
+								tracking.device_poses.push_back(
+								        from_headset::tracking::pose{
+								                // Zero position and velocities
+								                .pose = {
+								                        .orientation = {
+								                                .x = gaze_quat.x,
+								                                .y = gaze_quat.y,
+								                                .z = gaze_quat.z,
+								                                .w = gaze_quat.w,
+								                        },
+								                },
+								                .device = item.device,
+								                .flags = uint8_t(gaze.flags & view_pose.flags & ~(flags::linear_velocity_valid | flags::angular_velocity_valid)),
+								        });
 							}
 							break;
 						case wivrn::device_id::FACE:
@@ -759,37 +754,30 @@ void scenes::stream::send_derived_pose()
 		{
 			// This may happen if the runtime does not support palm ext
 			// check if we have a device specific offset
-			switch (guess_model())
+			if (not hmd_traits.hand_interaction_grip_surface)
 			{
-				case model::oculus_quest:
-				case model::oculus_quest_2:
-				case model::meta_quest_pro:
-				case model::meta_quest_3:
-				case model::meta_quest_3s:
-					switch (target)
-					{
-						case device_id::LEFT_PALM:
-						case device_id::RIGHT_PALM: {
-							glm::quat q(glm::vec3(glm::radians(-60.), 0, 0));
-							network_session->send_control(from_headset::derived_pose{
-							        .source = source,
-							        .target = target,
-							        .relation = {
-							                .orientation = {
-							                        .x = q.x,
-							                        .y = q.y,
-							                        .z = q.z,
-							                        .w = q.w,
-							                },
-							        },
-							});
-						}
-						break;
-						default:
-							break;
+				switch (target)
+				{
+					case device_id::LEFT_PALM:
+					case device_id::RIGHT_PALM: {
+						glm::quat q(glm::vec3(glm::radians(-60.), 0, 0));
+						network_session->send_control(from_headset::derived_pose{
+						        .source = source,
+						        .target = target,
+						        .relation = {
+						                .orientation = {
+						                        .x = q.x,
+						                        .y = q.y,
+						                        .z = q.z,
+						                        .w = q.w,
+						                },
+						        },
+						});
 					}
-				default:
 					break;
+					default:
+						break;
+				}
 			}
 		}
 		else

--- a/client/wivrn_client.cpp
+++ b/client/wivrn_client.cpp
@@ -18,7 +18,7 @@
  */
 
 #include "wivrn_client.h"
-#include "hardware.h"
+#include "application.h"
 #include "protocol_version.h"
 #include "secrets.h"
 #include "smp.h"
@@ -102,7 +102,7 @@ void wivrn_session::handshake(T address, bool tcp_only, crypto::key & headset_ke
 	send_control(from_headset::crypto_handshake{
 	        .protocol_version = wivrn::protocol_version,
 	        .public_key = headset_keypair.public_key(),
-	        .name = model_name(),
+	        .name = application::get_hmd_traits().model_name(),
 	});
 
 	to_headset::crypto_handshake crypto_handshake = std::get<to_headset::crypto_handshake>(receive(10s));

--- a/client/xr/face_tracker.cpp
+++ b/client/xr/face_tracker.cpp
@@ -45,18 +45,13 @@ xr::face_tracker_type xr::face_tracker_supported(xr::instance & instance, xr::sy
 			return xr::face_tracker_type::htc;
 	}
 
-	switch (guess_model())
+	if (hmd_traits.pico_face_tracker)
 	{
-		case model::pico_4_pro:
-		case model::pico_4_enterprise:
-			// The extension used by Pico is not published
-			// it doesn't even need to be requested...
-			if (instance.has_extension(XR_EXT_EYE_GAZE_INTERACTION_EXTENSION_NAME) and
-			    system.eye_gaze_interaction_properties().supportsEyeGazeInteraction)
-				return xr::face_tracker_type::pico;
-			break;
-		default:
-			break;
+		// The extension used by Pico is not published
+		// it doesn't even need to be requested...
+		if (instance.has_extension(XR_EXT_EYE_GAZE_INTERACTION_EXTENSION_NAME) and
+		    system.eye_gaze_interaction_properties().supportsEyeGazeInteraction)
+			return xr::face_tracker_type::pico;
 	}
 
 	return xr::face_tracker_type::none;
@@ -90,18 +85,13 @@ xr::face_tracker xr::make_face_tracker(xr::instance & instance, xr::system & sys
 			        properties.supportLipFacialTracking);
 	}
 
-	switch (guess_model())
+	if (hmd_traits.pico_face_tracker)
 	{
-		case model::pico_4_pro:
-		case model::pico_4_enterprise:
-			// The extension used by Pico is not published
-			// it doesn't even need to be requested...
-			if (instance.has_extension(XR_EXT_EYE_GAZE_INTERACTION_EXTENSION_NAME) and
-			    system.eye_gaze_interaction_properties().supportsEyeGazeInteraction)
-				return xr::face_tracker(std::in_place_type_t<xr::pico_face_tracker>(), instance, session);
-			break;
-		default:
-			break;
+		// The extension used by Pico is not published
+		// it doesn't even need to be requested...
+		if (instance.has_extension(XR_EXT_EYE_GAZE_INTERACTION_EXTENSION_NAME) and
+		    system.eye_gaze_interaction_properties().supportsEyeGazeInteraction)
+			return xr::face_tracker(std::in_place_type_t<xr::pico_face_tracker>(), instance, session);
 	}
 
 	return std::monostate();

--- a/client/xr/face_tracker.cpp
+++ b/client/xr/face_tracker.cpp
@@ -45,7 +45,7 @@ xr::face_tracker_type xr::face_tracker_supported(xr::instance & instance, xr::sy
 			return xr::face_tracker_type::htc;
 	}
 
-	if (hmd_traits.pico_face_tracker)
+	if (hmd_traits().pico_face_tracker)
 	{
 		// The extension used by Pico is not published
 		// it doesn't even need to be requested...
@@ -85,7 +85,7 @@ xr::face_tracker xr::make_face_tracker(xr::instance & instance, xr::system & sys
 			        properties.supportLipFacialTracking);
 	}
 
-	if (hmd_traits.pico_face_tracker)
+	if (hmd_traits().pico_face_tracker)
 	{
 		// The extension used by Pico is not published
 		// it doesn't even need to be requested...

--- a/client/xr/face_tracker.cpp
+++ b/client/xr/face_tracker.cpp
@@ -18,7 +18,7 @@
 
 #include "face_tracker.h"
 
-#include "hardware.h"
+#include "application.h"
 #include "xr/instance.h"
 #include "xr/system.h"
 
@@ -45,7 +45,7 @@ xr::face_tracker_type xr::face_tracker_supported(xr::instance & instance, xr::sy
 			return xr::face_tracker_type::htc;
 	}
 
-	if (hmd_traits().pico_face_tracker)
+	if (application::get_hmd_traits().pico_face_tracker)
 	{
 		// The extension used by Pico is not published
 		// it doesn't even need to be requested...
@@ -85,7 +85,7 @@ xr::face_tracker xr::make_face_tracker(xr::instance & instance, xr::system & sys
 			        properties.supportLipFacialTracking);
 	}
 
-	if (hmd_traits().pico_face_tracker)
+	if (application::get_hmd_traits().pico_face_tracker)
 	{
 		// The extension used by Pico is not published
 		// it doesn't even need to be requested...

--- a/client/xr/instance.cpp
+++ b/client/xr/instance.cpp
@@ -100,12 +100,11 @@ static std::pair<XrVersion, XrInstance> create_instance(XrInstanceCreateInfo & i
 	             XR_API_VERSION_1_0,
 	     })
 	{
-		const XrVersion max_openxr_api_version = runtime_hmd_traits().max_openxr_api_version;
-		if (version > max_openxr_api_version)
+		if (version > hmd_traits.max_openxr_api_version)
 		{
 			spdlog::info("skip OpenXR {} due to headset quirk max version {}",
 			             xr::to_string(version),
-			             xr::to_string(max_openxr_api_version));
+			             xr::to_string(hmd_traits.max_openxr_api_version));
 			continue;
 		}
 		std::vector<const char *> extensions;

--- a/client/xr/instance.cpp
+++ b/client/xr/instance.cpp
@@ -100,11 +100,11 @@ static std::pair<XrVersion, XrInstance> create_instance(XrInstanceCreateInfo & i
 	             XR_API_VERSION_1_0,
 	     })
 	{
-		if (version > hmd_traits.max_openxr_api_version)
+		if (version > hmd_traits().max_openxr_api_version)
 		{
 			spdlog::info("skip OpenXR {} due to headset quirk max version {}",
 			             xr::to_string(version),
-			             xr::to_string(hmd_traits.max_openxr_api_version));
+			             xr::to_string(hmd_traits().max_openxr_api_version));
 			continue;
 		}
 		std::vector<const char *> extensions;

--- a/client/xr/instance.cpp
+++ b/client/xr/instance.cpp
@@ -100,18 +100,13 @@ static std::pair<XrVersion, XrInstance> create_instance(XrInstanceCreateInfo & i
 	             XR_API_VERSION_1_0,
 	     })
 	{
-		switch (guess_model())
+		const XrVersion max_openxr_api_version = runtime_hmd_traits().max_openxr_api_version;
+		if (version > max_openxr_api_version)
 		{
-			case model::htc_vive_focus_3:
-			case model::htc_vive_xr_elite:
-			case model::htc_vive_focus_vision:
-				if (version > XR_API_VERSION_1_0)
-				{
-					spdlog::info("skip OpenXR 1.1 for HTC");
-					continue;
-				}
-			default:
-				break;
+			spdlog::info("skip OpenXR {} due to headset quirk max version {}",
+			             xr::to_string(version),
+			             xr::to_string(max_openxr_api_version));
+			continue;
 		}
 		std::vector<const char *> extensions;
 		info.applicationInfo.apiVersion = version;

--- a/client/xr/instance.cpp
+++ b/client/xr/instance.cpp
@@ -19,7 +19,7 @@
 
 #include "instance.h"
 
-#include "hardware.h"
+#include "application.h"
 #include "xr/details/enumerate.h"
 #include "xr/htc_exts.h"
 #include "xr/to_string.h"
@@ -100,11 +100,11 @@ static std::pair<XrVersion, XrInstance> create_instance(XrInstanceCreateInfo & i
 	             XR_API_VERSION_1_0,
 	     })
 	{
-		if (version > hmd_traits().max_openxr_api_version)
+		if (version > application::get_hmd_traits().max_openxr_api_version)
 		{
 			spdlog::info("skip OpenXR {} due to headset quirk max version {}",
 			             xr::to_string(version),
-			             xr::to_string(hmd_traits().max_openxr_api_version));
+			             xr::to_string(application::get_hmd_traits().max_openxr_api_version));
 			continue;
 		}
 		std::vector<const char *> extensions;


### PR DESCRIPTION
Previously, HMD-specific behavior (including workarounds for per-device runtime bugs) was scattered across in-function switch statements on `guess_model()`. This revision consolidates all HMD-specific behavior into a single `hmd_traits` struct that is initialized once at client startup.

## Design choices: 
- Explicit over implicit accesses: e.g. `runtime_hmd_traits().needs_srgb_conversion` instead of a global `needs_srgb_conversion()` function so performance and dependencies are clear at the caller level (with two important exceptions: fallback lazy-init in `runtime_hmd_traits()` and implicit use of `guess_model()` inside `initialize_runtime_hmd_traits()`).
- Global `runtime_hmd_traits` with one-time-init at top of `Application::Application()`: Populate all properties once during app init so init cost (e.g. model sysprop reads) is realized only once and never in the frame loop.   
- Sysprop/envvar overrides of traits at runtime: 
    - Sysprop (Android) and environment variable (linux) overrides can be used to simulate different hardware traits without access to that hardware. 
    - Checking once on init means you can't change the traits dynamically once the app is launched but 1) that wouldn't work well 2) sysprop reads are expensive enough that adding them to a hotpath can add lots of cycles no one wants.

## Testing
**Available Devices:** Oculus Quest, Meta Quest 2, Meta Quest 3, Lynx R1, Oculus Quest Pro, Play for Dream MR, Pico 4, Vive Focus 3  
**Missing Devices:** Samsung Galaxy XR, Pico Neo 3, Pico 4 Pro, Pico 4 Enterprise, Pico 4s, Vive XR Elite, Vive Focus Vision
**Devices Tested:** Meta Quest 3, Play for Dream MR, Pico 4
 
| Test | Steps | Expected |
|---|---|---|
| Trait correctness | Launch client, inspect logcat | `HMD traits:` log line matches output from debug log added to old version |
| Sysprop overrides | Set override sysprops, launch client, inspect logcat | `HMD trait overrides:` log line reflects override values |
| Permission prompts | Uninstall, install, launch local client | User is prompted with correct permissions requests for device |

Note: Since I'm not testing all supported devices, I additionally ran a homemade "static analysis" script to compare old/new codes versions to verify per-traits amount to the same thing across both versions

Test script for overrides [here](https://gist.github.com/amwatson/8f5efc4a15a9d8df93b5162edc255082)
Test script for devices configurations (assumes debug sysprops for devices I didn't add to the revision) [here](https://gist.github.com/amwatson/05b0e6202c7a616769d985f5676a2e35)