### PR TITLE
Fix vulkan encode QFOT layouts (NVIDIA green frame)

### DIFF
--- a/server/compositor/compositor.cpp
+++ b/server/compositor/compositor.cpp
@@ -442,6 +442,14 @@ xrt_result_t compositor::layer_commit(xrt_graphics_sync_handle_t sync_handle)
 			                .srcAccessMask = vk::AccessFlagBits2::eShaderStorageWrite,
 			                .dstStageMask = vk::PipelineStageFlagBits2::eAllCommands,
 			                .dstAccessMask = vk::AccessFlagBits2::eMemoryRead,
+			                // For a queue-family ownership transfer in EXCLUSIVE
+			                // sharing mode, the release barrier's old/new layout
+			                // must match the encoder-side acquire. Both sides use
+			                // eGeneral → eGeneral here; the encoder issues a
+			                // separate non-QFOT barrier to transition to its
+			                // required layout (eVideoEncodeSrcKHR, etc.).
+			                .oldLayout = vk::ImageLayout::eGeneral,
+			                .newLayout = vk::ImageLayout::eGeneral,
 			                .srcQueueFamilyIndex = vk.queue_family_index,
 			                .dstQueueFamilyIndex = encoder->target_queue,
 			                .image = images[i].image,

--- a/server/compositor/compositor.cpp
+++ b/server/compositor/compositor.cpp
@@ -442,6 +442,16 @@ xrt_result_t compositor::layer_commit(xrt_graphics_sync_handle_t sync_handle)
 			                .srcAccessMask = vk::AccessFlagBits2::eShaderStorageWrite,
 			                .dstStageMask = vk::PipelineStageFlagBits2::eAllCommands,
 			                .dstAccessMask = vk::AccessFlagBits2::eMemoryRead,
+			                // For a queue-family ownership transfer in EXCLUSIVE
+			                // sharing mode, the release barrier's old/new layout
+			                // must match the encoder-side acquire. newLayout is
+			                // the encoder's target_layout; per the VkImageMemoryBarrier2
+			                // spec the layout transition is executed exactly once
+			                // between the queues, so this single QFOT barrier covers
+			                // both the queue-family transfer and the layout
+			                // transition the encoder needs.
+			                .oldLayout = vk::ImageLayout::eGeneral,
+			                .newLayout = encoder->target_layout,
 			                .srcQueueFamilyIndex = vk.queue_family_index,
 			                .dstQueueFamilyIndex = encoder->target_queue,
 			                .image = images[i].image,

--- a/server/encoder/video_encoder.h
+++ b/server/encoder/video_encoder.h
@@ -78,6 +78,10 @@ public:
 	const uint8_t stream_idx;
 	const uint32_t target_queue;
 	const bool need_transfer;
+	// Layout the encoder needs y_cbcr to arrive in. Set during construction
+	// or init() and read by the compositor on every layer_commit — must not
+	// change after the first frame.
+	vk::ImageLayout target_layout = vk::ImageLayout::eGeneral;
 	static const uint8_t num_slots = 2;
 	const double bitrate_multiplier;
 

--- a/server/encoder/video_encoder_vulkan.cpp
+++ b/server/encoder/video_encoder_vulkan.cpp
@@ -638,14 +638,18 @@ void wivrn::video_encoder_vulkan::present_image(vk::Image y_cbcr, vk::SemaphoreS
 		compositor_sem.stageMask = vk::PipelineStageFlagBits2::eCopy;
 
 		beman::inplace_vector::inplace_vector<vk::ImageMemoryBarrier2, 2> im_barriers;
+		// y_cbcr was written by the compositor in eGeneral and stays in
+		// eGeneral here. eGeneral is a valid source layout for copyImage,
+		// so no layout transition is needed; the QFOT acquire below uses
+		// eGeneral → eGeneral to match the compositor's release.
 		vk::ImageLayout y_cbcr_layout{vk::ImageLayout::eGeneral};
 		if (need_transfer)
 		{
 			im_barriers.push_back(vk::ImageMemoryBarrier2{
 			        .dstStageMask = vk::PipelineStageFlagBits2KHR::eCopy,
 			        .dstAccessMask = vk::AccessFlagBits2::eTransferRead,
-			        .oldLayout = y_cbcr_layout,
-			        .newLayout = vk::ImageLayout::eTransferSrcOptimal,
+			        .oldLayout = vk::ImageLayout::eGeneral,
+			        .newLayout = vk::ImageLayout::eGeneral,
 			        .srcQueueFamilyIndex = vk.queue_family_index,
 			        .dstQueueFamilyIndex = target_queue,
 			        .image = y_cbcr,
@@ -655,7 +659,6 @@ void wivrn::video_encoder_vulkan::present_image(vk::Image y_cbcr, vk::SemaphoreS
 			                             .baseArrayLayer = stream_idx,
 			                             .layerCount = 1},
 			});
-			y_cbcr_layout = vk::ImageLayout::eTransferSrcOptimal;
 		}
 		im_barriers.push_back(vk::ImageMemoryBarrier2{
 		        .dstStageMask = vk::PipelineStageFlagBits2KHR::eCopy,
@@ -739,13 +742,15 @@ void wivrn::video_encoder_vulkan::present_image(vk::Image y_cbcr, vk::SemaphoreS
 	else
 	{
 		compositor_sem.stageMask = vk::PipelineStageFlagBits2::eVideoEncodeKHR;
+		// QFOT acquire (must match compositor's eGeneral → eGeneral release)
+		// followed by a non-QFOT layout transition to eVideoEncodeSrcKHR,
+		// which vkCmdEncodeVideoKHR requires.
+		beman::inplace_vector::inplace_vector<vk::ImageMemoryBarrier2, 2> im_barriers;
 		if (need_transfer)
 		{
-			vk::ImageMemoryBarrier2 video_barrier{
-			        .dstStageMask = vk::PipelineStageFlagBits2KHR::eVideoEncodeKHR,
-			        .dstAccessMask = vk::AccessFlagBits2::eVideoEncodeReadKHR,
+			im_barriers.push_back(vk::ImageMemoryBarrier2{
 			        .oldLayout = vk::ImageLayout::eGeneral,
-			        .newLayout = vk::ImageLayout::eVideoEncodeSrcKHR,
+			        .newLayout = vk::ImageLayout::eGeneral,
 			        .srcQueueFamilyIndex = vk.queue_family_index,
 			        .dstQueueFamilyIndex = target_queue,
 			        .image = y_cbcr,
@@ -754,12 +759,24 @@ void wivrn::video_encoder_vulkan::present_image(vk::Image y_cbcr, vk::SemaphoreS
 			                             .levelCount = 1,
 			                             .baseArrayLayer = stream_idx,
 			                             .layerCount = 1},
-			};
-			video_cmd_buf.pipelineBarrier2({
-			        .imageMemoryBarrierCount = 1,
-			        .pImageMemoryBarriers = &video_barrier,
 			});
 		}
+		im_barriers.push_back(vk::ImageMemoryBarrier2{
+		        .dstStageMask = vk::PipelineStageFlagBits2KHR::eVideoEncodeKHR,
+		        .dstAccessMask = vk::AccessFlagBits2::eVideoEncodeReadKHR,
+		        .oldLayout = vk::ImageLayout::eGeneral,
+		        .newLayout = vk::ImageLayout::eVideoEncodeSrcKHR,
+		        .image = y_cbcr,
+		        .subresourceRange = {.aspectMask = vk::ImageAspectFlagBits::eColor,
+		                             .baseMipLevel = 0,
+		                             .levelCount = 1,
+		                             .baseArrayLayer = stream_idx,
+		                             .layerCount = 1},
+		});
+		video_cmd_buf.pipelineBarrier2({
+		        .imageMemoryBarrierCount = uint32_t(im_barriers.size()),
+		        .pImageMemoryBarriers = im_barriers.data(),
+		});
 
 		auto it = image_views.find(VkImage(y_cbcr));
 		if (it != image_views.end())

--- a/server/encoder/video_encoder_vulkan.cpp
+++ b/server/encoder/video_encoder_vulkan.cpp
@@ -317,6 +317,13 @@ void wivrn::video_encoder_vulkan::init(const vk::VideoCapabilitiesKHR & video_ca
 		}
 	}
 
+	// tmp_image path: copyImage source accepts eGeneral, so no transition needed.
+	// Direct path: vkCmdEncodeVideoKHR requires eVideoEncodeSrcKHR — folding it
+	// into target_layout lets the QFOT barrier perform the transition in one step.
+	target_layout = tmp_image
+	                        ? vk::ImageLayout::eGeneral
+	                        : vk::ImageLayout::eVideoEncodeSrcKHR;
+
 	// Decode picture buffer (DPB) images
 	vk::VideoFormatPropertiesKHR reference_picture_format = select_video_format(
 	        vk.physical_device,
@@ -638,14 +645,13 @@ void wivrn::video_encoder_vulkan::present_image(vk::Image y_cbcr, vk::SemaphoreS
 		compositor_sem.stageMask = vk::PipelineStageFlagBits2::eCopy;
 
 		beman::inplace_vector::inplace_vector<vk::ImageMemoryBarrier2, 2> im_barriers;
-		vk::ImageLayout y_cbcr_layout{vk::ImageLayout::eGeneral};
 		if (need_transfer)
 		{
 			im_barriers.push_back(vk::ImageMemoryBarrier2{
 			        .dstStageMask = vk::PipelineStageFlagBits2KHR::eCopy,
 			        .dstAccessMask = vk::AccessFlagBits2::eTransferRead,
-			        .oldLayout = y_cbcr_layout,
-			        .newLayout = vk::ImageLayout::eTransferSrcOptimal,
+			        .oldLayout = vk::ImageLayout::eGeneral,
+			        .newLayout = target_layout,
 			        .srcQueueFamilyIndex = vk.queue_family_index,
 			        .dstQueueFamilyIndex = target_queue,
 			        .image = y_cbcr,
@@ -655,7 +661,6 @@ void wivrn::video_encoder_vulkan::present_image(vk::Image y_cbcr, vk::SemaphoreS
 			                             .baseArrayLayer = stream_idx,
 			                             .layerCount = 1},
 			});
-			y_cbcr_layout = vk::ImageLayout::eTransferSrcOptimal;
 		}
 		im_barriers.push_back(vk::ImageMemoryBarrier2{
 		        .dstStageMask = vk::PipelineStageFlagBits2KHR::eCopy,
@@ -677,7 +682,7 @@ void wivrn::video_encoder_vulkan::present_image(vk::Image y_cbcr, vk::SemaphoreS
 
 		video_cmd_buf.copyImage(
 		        y_cbcr,
-		        y_cbcr_layout,
+		        target_layout,
 		        tmp_image,
 		        vk::ImageLayout::eTransferDstOptimal,
 		        std::array{
@@ -739,27 +744,29 @@ void wivrn::video_encoder_vulkan::present_image(vk::Image y_cbcr, vk::SemaphoreS
 	else
 	{
 		compositor_sem.stageMask = vk::PipelineStageFlagBits2::eVideoEncodeKHR;
-		if (need_transfer)
-		{
-			vk::ImageMemoryBarrier2 video_barrier{
-			        .dstStageMask = vk::PipelineStageFlagBits2KHR::eVideoEncodeKHR,
-			        .dstAccessMask = vk::AccessFlagBits2::eVideoEncodeReadKHR,
-			        .oldLayout = vk::ImageLayout::eGeneral,
-			        .newLayout = vk::ImageLayout::eVideoEncodeSrcKHR,
-			        .srcQueueFamilyIndex = vk.queue_family_index,
-			        .dstQueueFamilyIndex = target_queue,
-			        .image = y_cbcr,
-			        .subresourceRange = {.aspectMask = vk::ImageAspectFlagBits::eColor,
-			                             .baseMipLevel = 0,
-			                             .levelCount = 1,
-			                             .baseArrayLayer = stream_idx,
-			                             .layerCount = 1},
-			};
-			video_cmd_buf.pipelineBarrier2({
-			        .imageMemoryBarrierCount = 1,
-			        .pImageMemoryBarriers = &video_barrier,
-			});
-		}
+		// Single barrier: when need_transfer, this is the QFOT acquire and
+		// carries the layout transition (eGeneral → target_layout) per the
+		// VkImageMemoryBarrier2 spec (executed once between the queues).
+		// When need_transfer is false (optimal cross-queue transfer, no QFOT)
+		// the same barrier degenerates to a plain layout transition.
+		vk::ImageMemoryBarrier2 barrier{
+		        .dstStageMask = vk::PipelineStageFlagBits2KHR::eVideoEncodeKHR,
+		        .dstAccessMask = vk::AccessFlagBits2::eVideoEncodeReadKHR,
+		        .oldLayout = vk::ImageLayout::eGeneral,
+		        .newLayout = target_layout,
+		        .srcQueueFamilyIndex = need_transfer ? vk.queue_family_index : vk::QueueFamilyIgnored,
+		        .dstQueueFamilyIndex = need_transfer ? target_queue : vk::QueueFamilyIgnored,
+		        .image = y_cbcr,
+		        .subresourceRange = {.aspectMask = vk::ImageAspectFlagBits::eColor,
+		                             .baseMipLevel = 0,
+		                             .levelCount = 1,
+		                             .baseArrayLayer = stream_idx,
+		                             .layerCount = 1},
+		};
+		video_cmd_buf.pipelineBarrier2({
+		        .imageMemoryBarrierCount = 1,
+		        .pImageMemoryBarriers = &barrier,
+		});
 
 		auto it = image_views.find(VkImage(y_cbcr));
 		if (it != image_views.end())

--- a/server/utils/wivrn_vk_bundle.cpp
+++ b/server/utils/wivrn_vk_bundle.cpp
@@ -419,8 +419,8 @@ bool wivrn::vk_bundle::optimal_transfer(uint32_t from, uint32_t to) const
 	{
 		auto props = physical_device.getQueueFamilyProperties2<vk::StructureChain<vk::QueueFamilyProperties2, vk::QueueFamilyOwnershipTransferPropertiesKHR>>();
 
-		auto to = std::get<1>(props[from]).optimalImageTransferToQueueFamilies;
-		return to & (1 << to);
+		auto mask = std::get<1>(props[from]).optimalImageTransferToQueueFamilies;
+		return (mask & (1u << to)) != 0;
 	}
 #endif
 	return true;


### PR DESCRIPTION
The compositor's release barrier left old/newLayout defaulted to eUndefined while the encoder's acquire used eGeneral -> eVideoEncodeSrcKHR (or eTransferSrcOptimal on the NVIDIA tmp_image path), which the spec forbids for an exclusive-mode queue-family ownership transfer. NVIDIA honoured the mismatch by treating the encode-queue contents as undefined (zeros), giving Y=0/CbCr=0 -- solid green.

Also fix optimal_transfer(): the inner `auto to = ...` shadowed the parameter, so the maintenance9 check returned mask & (1 << mask) instead of mask & (1 << dst_qfi) and was effectively always false.

Release/acquire now agree on eGeneral -> eGeneral; the encoder issues a second non-QFOT barrier to reach eVideoEncodeSrcKHR before encodeVideoKHR.