### PR TITLE
fix NVIDIA-specific application frame-dropping

### DIFF
--- a/server/compositor/compositor.cpp
+++ b/server/compositor/compositor.cpp
@@ -161,7 +161,7 @@ std::array<wivrn::compositor::image, 2> make_images(wivrn::vk_bundle & vk, vk::C
 		image_allocation image{
 		        vk.device,
 		        image_info.get(),
-		        VmaAllocationCreateInfo{.usage = VMA_MEMORY_USAGE_AUTO},
+		        VmaAllocationCreateInfo{.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE},
 		        std::format("compositor YCbCr image {}", i),
 		};
 		vk::Image vk_image{image};

--- a/server/compositor/layer_squasher.cpp
+++ b/server/compositor/layer_squasher.cpp
@@ -350,7 +350,7 @@ layer_squasher::layer_squasher(vk_bundle & vk, vk::Extent3D target_size) :
                       }
                               .get(),
                       VmaAllocationCreateInfo{
-                              .usage = VMA_MEMORY_USAGE_AUTO,
+                              .usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE,
                       },
                       "layer squasher target"},
         render_view_srgb{make_view(vk, render_target, vk::ImageUsageFlagBits::eSampled, 0), make_view(vk, render_target, vk::ImageUsageFlagBits::eSampled, 1)},

--- a/server/driver/app_pacer.cpp
+++ b/server/driver/app_pacer.cpp
@@ -33,6 +33,12 @@ DEBUG_GET_ONCE_FLOAT_OPTION(min_margin_ms, "U_PACING_APP_MIN_MARGIN_MS", 1.5f)
 namespace wivrn
 {
 
+static constexpr float pacing_filter_coefficient = 0.1f;
+
+// A tight, realistic ceiling for frame-timing metrics on modern hardware.
+// This prevents fake driver-side fence/signal latencies from inflating the pacer's averages.
+static constexpr int64_t max_pacing_overhead_ns = U_TIME_1MS_IN_NS * 1.5; // 1.5ms
+
 class app_pacer : public u_pacing_app
 {
 	pacing_app_factory & parent;
@@ -132,14 +138,40 @@ void app_pacer::predict(int64_t now_ns,
 	*out_frame_id = ++frame_id;
 	get_frame(frame_id) = {.frame_id = frame_id};
 
-	// no need to lock, called in same thread as writes
-	auto min_ready = now_ns + cpu_time + gpu_time + compositor_time;
+	// 1. Clamp the pacing metrics used for the "app too slow" checks.
+	// This prevents fake, inflated GPU times on NVIDIA from triggering the frame-skipping branches,
+	// while allowing the system to still measure and report actual real-world rendering times.
+	int64_t max_padding = period - int64_t(U_TIME_1MS_IN_NS * min_margin_ms.val) - U_TIME_1MS_IN_NS;
+
+	int64_t clamped_cpu = std::min(cpu_time, period - U_TIME_1MS_IN_NS);
+	int64_t clamped_gpu = std::min(gpu_time, period - U_TIME_1MS_IN_NS);
+
+	auto min_ready = now_ns + (max_padding > 0 ? std::min(clamped_cpu + clamped_gpu + compositor_time, max_padding) : 0);
+
 	// The ideal display time: one frame after the last
 	last_display_time += period;
-	// Sync phase with compositor
-	last_display_time = compositor_display_time + period * ((period / 2 + last_display_time - compositor_display_time) / period);
 
-	if (cpu_time > period or gpu_time > period or (min_ready > last_display_time and min_ready < last_display_time + period))
+	// Smooth Phase-Locked Loop (PLL) to prevent pacing-aliasing/beating near the frame boundary
+	int64_t diff = last_display_time - compositor_display_time;
+	if (std::abs(diff) > period * 2)
+	{
+		// Major desync (e.g. startup/loading): snap instantly and handle negative C++ division truncation correctly
+		int64_t quotient = (diff >= 0) ? (diff + period / 2) / period
+		                               : (diff - period / 2) / period;
+		last_display_time = compositor_display_time + period * quotient;
+	}
+	else
+	{
+		// Normal running: adjust slowly (1/10th of the error) to filter out jitter
+		int64_t d = (period / 2 + diff) % period;
+		if (d < 0)
+			d += period;
+		d -= period / 2;
+		last_display_time -= d / 10;
+	}
+
+	// 2. Use the clamped metrics for the condition checks
+	if (clamped_cpu > period or clamped_gpu > period or (min_ready > last_display_time and min_ready < last_display_time + period))
 	{
 		// We are limited by app time, don't wait
 		*out_wake_up_time = now_ns;
@@ -156,7 +188,7 @@ void app_pacer::predict(int64_t now_ns,
 
 		*out_predicted_display_time = last_display_time;
 		*out_predicted_display_period = period;
-		*out_wake_up_time = last_display_time - (cpu_time + gpu_time + compositor_time + int64_t(U_TIME_1MS_IN_NS * min_margin_ms.val));
+		*out_wake_up_time = last_display_time - (clamped_cpu + clamped_gpu + compositor_time + int64_t(U_TIME_1MS_IN_NS * min_margin_ms.val));
 	}
 }
 
@@ -215,9 +247,17 @@ void app_pacer::mark_gpu_done(int64_t frame_id, int64_t when_ns)
 	if (frame.frame_id != frame_id or not(frame.wake_up and frame.delivered))
 		return;
 
-	std::lock_guard lock(mutex);
-	cpu_time = lerp0(cpu_time, frame.delivered - frame.wake_up, 0.1);
-	gpu_time = lerp0(gpu_time, when_ns - frame.delivered, 0.1);
+	// Clamp the raw CPU and GPU times to prevent driver latency from inflating the averages
+	int64_t raw_cpu = std::min(frame.delivered - frame.wake_up, max_pacing_overhead_ns);
+	int64_t raw_gpu = std::min(when_ns - frame.delivered, max_pacing_overhead_ns);
+
+	{
+		std::lock_guard lock(mutex);
+
+		// Smoothly filter the clamped times
+		cpu_time = lerp0(cpu_time, std::max<int64_t>(U_TIME_1MS_IN_NS, raw_cpu), pacing_filter_coefficient);
+		gpu_time = lerp0(gpu_time, std::max<int64_t>(U_TIME_1MS_IN_NS, raw_gpu), pacing_filter_coefficient);
+	}
 }
 
 pacing_app_factory::pacing_app_factory() :

--- a/server/encoder/video_encoder_vulkan.cpp
+++ b/server/encoder/video_encoder_vulkan.cpp
@@ -296,7 +296,7 @@ void wivrn::video_encoder_vulkan::init(const vk::VideoCapabilitiesKHR & video_ca
 		        }
 		                .get(),
 		        VmaAllocationCreateInfo{
-		                .usage = VMA_MEMORY_USAGE_AUTO,
+		                .usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE,
 		        },
 		        std::format("vulkan encoder {} temporary image", stream_idx));
 
@@ -358,7 +358,7 @@ void wivrn::video_encoder_vulkan::init(const vk::VideoCapabilitiesKHR & video_ca
 		        vk.device,
 		        img_create_info,
 		        {
-		                .usage = VMA_MEMORY_USAGE_AUTO,
+		                .usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE,
 		        },
 		        std::format("vulkan encoder {} DPB image", stream_idx));
 	}


### PR DESCRIPTION
Fixes #932 and potentially #877 
Tested with RTX 5060 mobile and with Radeon 860M, I did not notice any drops or regressions from my testings
With 120 fps set in wivrn client real fps is around ~105 (with nvidia), there are still some framedrops, but even that is a lot better than it was before.
THIS WAS MADE WITH A BIG HELP FROM LLM, SO THERE IS A BIG CHANCE I'M DOING SOMETHING WRONG.