### PR TITLE
Adds "or Pico" to the text of the troubleshooting docs telling to look in the unknown sources directory

### DIFF
--- a/dashboard/qml/TroubleshootPage.qml
+++ b/dashboard/qml/TroubleshootPage.qml
@@ -18,7 +18,7 @@ Kirigami.ScrollablePage {
 
         TroubleshootCard {
             title: i18n("I cannot find the WiVRn app on my headset")
-            details: i18n("If you installed WiVRn over USB on a Meta headset, the app is in the \"unknown sources\" section.")
+            details: i18n("If you installed WiVRn over USB on a Meta or Pico headset, the app is in the \"unknown sources\" section.")
         }
         TroubleshootCard {
             title: i18n("I cannot see my computer in the WiVRn app")

--- a/dashboard/qml/WizardPage.qml
+++ b/dashboard/qml/WizardPage.qml
@@ -350,7 +350,7 @@ Kirigami.ScrollablePage {
             }
             BetterLabel {
                 Layout.fillWidth: true
-                text: i18n("If you installed WiVRn over USB on a Meta headset, the app is in the \"unknown sources\" section.")
+                text: i18n("If you installed WiVRn over USB on a Meta or Pico headset, the app is in the \"unknown sources\" section.")
                 Layout.topMargin: Kirigami.Units.largeSpacing
             }
             BetterLabel {


### PR DESCRIPTION
because the advice applies to Pico headsets too