### PR TITLE
README: use friendlier log locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,10 @@ If the server list is empty in the headset app:
 
 <details><summary>How do I see server logs when using the dashboard?</summary>
 
-- Click Troubleshoot > Open server logs, or
-- Navigate to `${XDG_STATE_HOME}/wivrn/wivrn-dashboard` (with fallback to `${HOME}/.local/state` for `${XDG_STATE_HOME}`, or
-- For flatpak, navigate to `${HOME}/.var/app/io.github.wivrn.wivrn/.local/state/wivrn/wivrn-dashboard`.</details>
+- Click **Troubleshoot > Open server logs**
+- Or, navigate to `${XDG_STATE_HOME}/wivrn/wivrn-dashboard`
+  - In other words, on common setups, the dashboard writes logs to `~/.local/state/wivrn/wivrn-dashboard`
+  - For WiVRn Flatpak, the dashboard writes logs to `~/.var/app/io.github.wivrn.wivrn/.local/state/wivrn/wivrn-dashboard`</details>
 
 <details><summary>My NVIDIA GPU P-State is limited to P2 instead of reaching the highest P0 while using the NVIDIA NVENC encoder</summary>
     


### PR DESCRIPTION
I talked to a few people who

1. Had no idea what the XDG Directory Spec vars were, and were plugging them into the file browser outright
2. Didn't see the dedicated dashboard button for logs

So, use the most likely location first and let the fallback be a fallback. And move "Or," to the beginning which should hint that they've skipped over the easiest option.