### PR TITLE
Add gamepad forwarding from the headset to the server

### DIFF
--- a/client/android/hid.cpp
+++ b/client/android/hid.cpp
@@ -249,10 +249,13 @@ bool android_hid::input_handler::handle_input(scene * current_scene, AInputEvent
 {
 	const int32_t type = AInputEvent_getType(event);
 	const int32_t src = AInputEvent_getSource(event);
-	const int32_t dev = AInputEvent_getDeviceId(event);
 
 	if (type == AINPUT_EVENT_TYPE_KEY)
 	{
+		// Gamepad input is read through the OpenXR microsoft/xbox_controller profile, not here.
+		if ((src & AINPUT_SOURCE_GAMEPAD) == AINPUT_SOURCE_GAMEPAD)
+			return false;
+
 		int32_t flags = AKeyEvent_getFlags(event);
 		if ((flags & AKEY_EVENT_FLAG_SOFT_KEYBOARD) != 0)
 			return false; // ignore soft keyboards
@@ -288,6 +291,10 @@ bool android_hid::input_handler::handle_input(scene * current_scene, AInputEvent
 
 	if (type == AINPUT_EVENT_TYPE_MOTION)
 	{
+		// Gamepad axes are read through the OpenXR microsoft/xbox_controller profile, not here.
+		if ((src & AINPUT_SOURCE_JOYSTICK) == AINPUT_SOURCE_JOYSTICK)
+			return false;
+
 		// don't care about absolute mouse due to mapping difficulties
 		if ((src & AINPUT_SOURCE_MOUSE_RELATIVE) == 0)
 			return false;

--- a/client/application.cpp
+++ b/client/application.cpp
@@ -39,6 +39,7 @@
 #include <boost/locale.hpp>
 #include <boost/url/parse.hpp>
 #include <chrono>
+#include <cstring>
 #include <ctype.h>
 #include <exception>
 #include <magic_enum.hpp>
@@ -602,6 +603,35 @@ static std::vector<interaction_profile> interaction_profiles{
                         "/user/eyes_ext/input/gaze_ext/pose",
                 },
         },
+        interaction_profile{
+                .profile_name = "/interaction_profiles/microsoft/xbox_controller",
+                .input_sources = {
+                        "/user/gamepad/input/menu/click",
+                        "/user/gamepad/input/view/click",
+                        "/user/gamepad/input/a/click",
+                        "/user/gamepad/input/b/click",
+                        "/user/gamepad/input/x/click",
+                        "/user/gamepad/input/y/click",
+                        "/user/gamepad/input/dpad_up/click",
+                        "/user/gamepad/input/dpad_down/click",
+                        "/user/gamepad/input/dpad_left/click",
+                        "/user/gamepad/input/dpad_right/click",
+                        "/user/gamepad/input/shoulder_left/click",
+                        "/user/gamepad/input/shoulder_right/click",
+                        "/user/gamepad/input/thumbstick_left/click",
+                        "/user/gamepad/input/thumbstick_right/click",
+                        "/user/gamepad/input/trigger_left/value",
+                        "/user/gamepad/input/trigger_right/value",
+                        "/user/gamepad/input/thumbstick_left/x",
+                        "/user/gamepad/input/thumbstick_left/y",
+                        "/user/gamepad/input/thumbstick_right/x",
+                        "/user/gamepad/input/thumbstick_right/y",
+                        "/user/gamepad/output/haptic_left",
+                        "/user/gamepad/output/haptic_right",
+                        "/user/gamepad/output/haptic_left_trigger",
+                        "/user/gamepad/output/haptic_right_trigger",
+                },
+        },
 };
 
 static const std::pair<std::string_view, XrActionType> action_suffixes[] =
@@ -634,11 +664,15 @@ static const std::pair<std::string_view, XrActionType> action_suffixes[] =
 		{"/ready_ext", XR_ACTION_TYPE_BOOLEAN_INPUT},
 
 		// Output paths
-		{"/haptic",           XR_ACTION_TYPE_VIBRATION_OUTPUT},
-		{"/haptic_trigger",   XR_ACTION_TYPE_VIBRATION_OUTPUT},
-		{"/haptic_trigger_fb",XR_ACTION_TYPE_VIBRATION_OUTPUT},
-		{"/haptic_thumb",     XR_ACTION_TYPE_VIBRATION_OUTPUT},
-		{"/haptic_thumb_fb",  XR_ACTION_TYPE_VIBRATION_OUTPUT},
+		{"/haptic",              XR_ACTION_TYPE_VIBRATION_OUTPUT},
+		{"/haptic_trigger",      XR_ACTION_TYPE_VIBRATION_OUTPUT},
+		{"/haptic_trigger_fb",   XR_ACTION_TYPE_VIBRATION_OUTPUT},
+		{"/haptic_thumb",        XR_ACTION_TYPE_VIBRATION_OUTPUT},
+		{"/haptic_thumb_fb",     XR_ACTION_TYPE_VIBRATION_OUTPUT},
+		{"/haptic_left",         XR_ACTION_TYPE_VIBRATION_OUTPUT},
+		{"/haptic_right",        XR_ACTION_TYPE_VIBRATION_OUTPUT},
+		{"/haptic_left_trigger", XR_ACTION_TYPE_VIBRATION_OUTPUT},
+		{"/haptic_right_trigger",XR_ACTION_TYPE_VIBRATION_OUTPUT},
                 // clang-format on
 };
 
@@ -1717,8 +1751,10 @@ void application::run()
 		while (ALooper_pollOnce(100, nullptr, &events, (void **)&source) >= 0)
 		{
 			// Process this event.
-			if (source != nullptr)
-				source->process(app_info.native_app, source);
+			if (source == nullptr)
+				continue;
+
+			source->process(app_info.native_app, source);
 		}
 
 		if (app_info.native_app->destroyRequested)

--- a/client/application.h
+++ b/client/application.h
@@ -206,6 +206,11 @@ public:
 	{
 		return instance().app_info.native_app;
 	}
+
+	static android_hid::input_handler & get_input_handler()
+	{
+		return instance().input_handler;
+	}
 #endif
 
 	static bool is_session_running()

--- a/client/configuration.cpp
+++ b/client/configuration.cpp
@@ -180,6 +180,15 @@ configuration::configuration(xr::system & system, xr::session & session)
 		if (auto val = root["mic_unprocessed_audio"]; val.is_bool())
 			mic_unprocessed_audio = val.get_bool();
 
+		if (auto val = root["forward_keyboard"]; val.is_bool())
+			forward_keyboard = val.get_bool();
+
+		if (auto val = root["forward_mouse"]; val.is_bool())
+			forward_mouse = val.get_bool();
+
+		if (auto val = root["forward_gamepad"]; val.is_bool())
+			forward_gamepad = val.get_bool();
+
 		if (auto val = root["fb_lower_body"]; val.is_bool())
 			fb_lower_body = val.get_bool();
 		if (auto val = root["fb_hip"]; val.is_bool())
@@ -296,6 +305,9 @@ void configuration::save()
 	write_openxr_post_processing(json, openxr_post_processing);
 	json << ",\"passthrough_enabled\":" << std::boolalpha << passthrough_enabled;
 	json << ",\"mic_unprocessed_audio\":" << std::boolalpha << mic_unprocessed_audio;
+	json << ",\"forward_keyboard\":" << std::boolalpha << forward_keyboard;
+	json << ",\"forward_mouse\":" << std::boolalpha << forward_mouse;
+	json << ",\"forward_gamepad\":" << std::boolalpha << forward_gamepad;
 	json << ",\"fb_lower_body\":" << std::boolalpha << fb_lower_body;
 	json << ",\"fb_hip\":" << std::boolalpha << fb_hip;
 	json << ",\"enable_stream_gui\":" << std::boolalpha << enable_stream_gui;

--- a/client/configuration.h
+++ b/client/configuration.h
@@ -68,6 +68,11 @@ public:
 	bool passthrough_enabled = false;
 	bool mic_unprocessed_audio = false;
 
+	// Input forwarding, per device. Off by default; only effective if the server permits it.
+	bool forward_keyboard = false;
+	bool forward_mouse = false;
+	bool forward_gamepad = false;
+
 	bool fb_lower_body = false;
 	bool fb_hip = true;
 

--- a/client/scenes/lobby.cpp
+++ b/client/scenes/lobby.cpp
@@ -867,6 +867,8 @@ void scenes::lobby::render(const XrFrameState & frame_state)
 
 	if (next_scene)
 	{
+		server_hid_forwarding = next_scene->hid_forwarding_enabled();
+
 		switch (next_scene->current_state())
 		{
 			case scenes::stream::state::streaming:

--- a/client/scenes/lobby.h
+++ b/client/scenes/lobby.h
@@ -63,6 +63,10 @@ class lobby : public scene_impl<lobby>
 	std::string server_name;
 	bool autoconnect_enabled = true;
 
+	// Last known uinput forwarding state of the connected server, kept after disconnection so the
+	// settings can warn that forwarded keyboard and mouse will not reach the server.
+	std::optional<bool> server_hid_forwarding;
+
 	std::optional<input_profile> input;
 	entt::entity lobby_entity;
 

--- a/client/scenes/lobby_gui.cpp
+++ b/client/scenes/lobby_gui.cpp
@@ -784,6 +784,32 @@ void scenes::lobby::gui_settings()
 		ImGui::Unindent();
 		ImGui::EndDisabled();
 	}
+	{
+		// Virtual devices: a keyboard, mouse or gamepad connected to the headset is
+		// replicated on the server through uinput. The gamepad is also exposed through
+		// OpenXR, whether or not it is mirrored to a virtual device.
+		ImGui::Text("%s", _S("Virtual devices"));
+		if (ImGui::IsItemHovered())
+			imgui_ctx->tooltip(_("Input devices connected to the headset are replicated as virtual devices on the PC.\nThe server must allow forwarded input devices; this is not available when the server runs as Flatpak.\nA gamepad is also usable without a virtual device by applications that read it through OpenXR."));
+		ImGui::Indent();
+		if (ImGui::Checkbox(_S("Keyboard"), &config.forward_keyboard))
+			config.save();
+		imgui_ctx->vibrate_on_hover();
+		if (ImGui::Checkbox(_S("Mouse"), &config.forward_mouse))
+			config.save();
+		imgui_ctx->vibrate_on_hover();
+		if (ImGui::Checkbox(_S("Gamepad"), &config.forward_gamepad))
+			config.save();
+		imgui_ctx->vibrate_on_hover();
+		ImGui::Unindent();
+
+		if (server_hid_forwarding == false and (config.forward_keyboard or config.forward_mouse or config.forward_gamepad))
+		{
+			ImGui::TextColored(constants::style::warn, ICON_FA_TRIANGLE_EXCLAMATION);
+			ImGui::SameLine();
+			ImGui::Text("%s", _S("The server does not allow forwarded input devices"));
+		}
+	}
 	if (system.hand_tracking_supported())
 	{
 		bool enabled = config.check_feature(feature::hand_tracking);

--- a/client/scenes/stream.cpp
+++ b/client/scenes/stream.cpp
@@ -138,6 +138,27 @@ static const std::unordered_map<std::string, device_id> device_ids = {
 	{"/user/hand/right/input/aim_activate_ext/ready_ext",device_id::RIGHT_AIM_ACTIVATE_READY},
 	{"/user/hand/right/input/grasp_ext/value",      device_id::RIGHT_GRASP_VALUE},
 	{"/user/hand/right/input/grasp_ext/ready_ext",  device_id::RIGHT_GRASP_READY},
+
+	{"/user/gamepad/input/menu/click",             device_id::GAMEPAD_MENU_CLICK},
+	{"/user/gamepad/input/view/click",             device_id::GAMEPAD_VIEW_CLICK},
+	{"/user/gamepad/input/a/click",                device_id::GAMEPAD_A_CLICK},
+	{"/user/gamepad/input/b/click",                device_id::GAMEPAD_B_CLICK},
+	{"/user/gamepad/input/x/click",                device_id::GAMEPAD_X_CLICK},
+	{"/user/gamepad/input/y/click",                device_id::GAMEPAD_Y_CLICK},
+	{"/user/gamepad/input/dpad_down/click",        device_id::GAMEPAD_DPAD_DOWN_CLICK},
+	{"/user/gamepad/input/dpad_right/click",       device_id::GAMEPAD_DPAD_RIGHT_CLICK},
+	{"/user/gamepad/input/dpad_up/click",          device_id::GAMEPAD_DPAD_UP_CLICK},
+	{"/user/gamepad/input/dpad_left/click",        device_id::GAMEPAD_DPAD_LEFT_CLICK},
+	{"/user/gamepad/input/shoulder_left/click",    device_id::GAMEPAD_SHOULDER_LEFT_CLICK},
+	{"/user/gamepad/input/shoulder_right/click",   device_id::GAMEPAD_SHOULDER_RIGHT_CLICK},
+	{"/user/gamepad/input/thumbstick_left/click",  device_id::GAMEPAD_THUMBSTICK_LEFT_CLICK},
+	{"/user/gamepad/input/thumbstick_right/click", device_id::GAMEPAD_THUMBSTICK_RIGHT_CLICK},
+	{"/user/gamepad/input/trigger_left/value",     device_id::GAMEPAD_TRIGGER_LEFT_VALUE},
+	{"/user/gamepad/input/trigger_right/value",    device_id::GAMEPAD_TRIGGER_RIGHT_VALUE},
+	{"/user/gamepad/input/thumbstick_left/x",      device_id::GAMEPAD_THUMBSTICK_LEFT_X},
+	{"/user/gamepad/input/thumbstick_left/y",      device_id::GAMEPAD_THUMBSTICK_LEFT_Y},
+	{"/user/gamepad/input/thumbstick_right/x",     device_id::GAMEPAD_THUMBSTICK_RIGHT_X},
+	{"/user/gamepad/input/thumbstick_right/y",     device_id::GAMEPAD_THUMBSTICK_RIGHT_Y},
 };
 // clang-format on
 
@@ -380,7 +401,12 @@ std::shared_ptr<scenes::stream> scenes::stream::create(std::unique_ptr<wivrn_ses
 	             std::tuple(device_id::LEFT_THUMB_HAPTIC, "/user/hand/left", "/output/haptic_thumb"),
 	             std::tuple(device_id::RIGHT_THUMB_HAPTIC, "/user/hand/right", "/output/haptic_thumb"),
 	             std::tuple(device_id::LEFT_THUMB_HAPTIC, "/user/hand/left", "/output/haptic_thumb_fb"),
-	             std::tuple(device_id::RIGHT_THUMB_HAPTIC, "/user/hand/right", "/output/haptic_thumb_fb")})
+	             std::tuple(device_id::RIGHT_THUMB_HAPTIC, "/user/hand/right", "/output/haptic_thumb_fb"),
+
+	             std::tuple(device_id::GAMEPAD_HAPTIC_LEFT, "/user/gamepad", "/output/haptic_left"),
+	             std::tuple(device_id::GAMEPAD_HAPTIC_RIGHT, "/user/gamepad", "/output/haptic_right"),
+	             std::tuple(device_id::GAMEPAD_HAPTIC_LEFT_TRIGGER, "/user/gamepad", "/output/haptic_left_trigger"),
+	             std::tuple(device_id::GAMEPAD_HAPTIC_RIGHT_TRIGGER, "/user/gamepad", "/output/haptic_right_trigger")})
 	{
 		if (auto action = application::get_action(std::string(path) + output); action.first)
 		{

--- a/client/scenes/stream.cpp
+++ b/client/scenes/stream.cpp
@@ -265,6 +265,7 @@ std::shared_ptr<scenes::stream> scenes::stream::create(std::unique_ptr<wivrn_ses
 		}
 
 		info.settings.bitrate_bps = config.bitrate_bps;
+		info.settings.mirror_gamepad = config.forward_gamepad;
 
 		info.hand_tracking = config.check_feature(feature::hand_tracking);
 		info.eye_gaze = config.check_feature(feature::eye_gaze);
@@ -1362,9 +1363,10 @@ void scenes::stream::on_xr_event(const xr::event & event)
 	}
 }
 
-bool scenes::stream::forward_hid_input(from_headset::hid::input_t packet)
+bool scenes::stream::forward_hid_input(from_headset::hid::input_t packet, bool device_enabled)
 {
-	if (not hid_forwarding)
+	// hid_forwarding is whether the server permits it; device_enabled is the headset toggle.
+	if (not hid_forwarding or not device_enabled)
 		return false;
 	network_session->send_control(from_headset::hid::input{packet});
 	return true;
@@ -1372,25 +1374,25 @@ bool scenes::stream::forward_hid_input(from_headset::hid::input_t packet)
 
 bool scenes::stream::on_input_key_down(uint8_t key_code)
 {
-	return forward_hid_input(from_headset::hid::key_down{key_code});
+	return forward_hid_input(from_headset::hid::key_down{key_code}, application::get_config().forward_keyboard);
 }
 bool scenes::stream::on_input_key_up(uint8_t key_code)
 {
-	return forward_hid_input(from_headset::hid::key_up{key_code});
+	return forward_hid_input(from_headset::hid::key_up{key_code}, application::get_config().forward_keyboard);
 }
 bool scenes::stream::on_input_mouse_move(float x, float y)
 {
-	return forward_hid_input(from_headset::hid::mouse_move{x, y});
+	return forward_hid_input(from_headset::hid::mouse_move{x, y}, application::get_config().forward_mouse);
 }
 bool scenes::stream::on_input_button_down(uint8_t button)
 {
-	return forward_hid_input(from_headset::hid::button_down{button});
+	return forward_hid_input(from_headset::hid::button_down{button}, application::get_config().forward_mouse);
 }
 bool scenes::stream::on_input_button_up(uint8_t button)
 {
-	return forward_hid_input(from_headset::hid::button_up{button});
+	return forward_hid_input(from_headset::hid::button_up{button}, application::get_config().forward_mouse);
 }
 bool scenes::stream::on_input_scroll(float h, float v)
 {
-	return forward_hid_input(from_headset::hid::mouse_scroll{h, v});
+	return forward_hid_input(from_headset::hid::mouse_scroll{h, v}, application::get_config().forward_mouse);
 }

--- a/client/scenes/stream.h
+++ b/client/scenes/stream.h
@@ -32,6 +32,7 @@
 #include "wivrn_packets.h"
 #include "xr/space.h"
 #include <mutex>
+#include <optional>
 #include <queue>
 #include <shared_mutex>
 #include <thread>
@@ -188,7 +189,7 @@ private:
 
 	stream(std::string server_name, scene & parent_scene);
 
-	bool forward_hid_input(from_headset::hid::input_t);
+	bool forward_hid_input(from_headset::hid::input_t, bool device_enabled);
 
 public:
 	~stream();
@@ -237,6 +238,13 @@ public:
 	state current_state() const
 	{
 		return state_;
+	}
+
+	// Whether the server mirrors forwarded input devices to uinput. The gamepad is also exposed
+	// through OpenXR regardless, so this only affects forwarded keyboard and mouse.
+	bool hid_forwarding_enabled() const
+	{
+		return hid_forwarding;
 	}
 
 	void exit();

--- a/client/scenes/stream.h
+++ b/client/scenes/stream.h
@@ -76,7 +76,7 @@ private:
 	std::unique_ptr<wivrn_session> network_session;
 	std::thread network_thread;
 	thread_safe<to_headset::tracking_control> tracking_control{};
-	std::array<std::atomic<interaction_profile>, 2> interaction_profiles; // left and right hand
+	std::array<std::atomic<interaction_profile>, 3> interaction_profiles; // left hand, right hand, gamepad
 	std::atomic<bool> interaction_profile_changed = false;
 	std::atomic<XrTime> scheduled_derived_pose = 0; // Tracking thread will compute derived pose when time is reached
 	std::atomic<bool> recenter_requested = false;

--- a/client/scenes/stream_gui.cpp
+++ b/client/scenes/stream_gui.cpp
@@ -387,6 +387,7 @@ static void send_settings_changed_packet(xr::session & session, wivrn_session * 
 	                .minimum_refresh_rate = config.minimum_refresh_rate.value_or(0),
 	                .fps_divider = config.fps_divider,
 	                .bitrate_bps = config.bitrate_bps,
+	                .mirror_gamepad = config.forward_gamepad,
 	        });
 }
 

--- a/client/scenes/stream_network.cpp
+++ b/client/scenes/stream_network.cpp
@@ -19,10 +19,8 @@
 
 #include "stream.h"
 
-#ifdef __ANDROID__
 #include "application.h"
-#endif
-
+#include "utils/i18n.h"
 #include "utils/named_thread.h"
 
 #include <spdlog/spdlog.h>
@@ -87,6 +85,12 @@ void scenes::stream::operator()(to_headset::feature_control && control)
 	{
 		case wivrn::to_headset::feature_control::hid_input:
 			hid_forwarding = control.state;
+			if (not control.state and (application::get_config().forward_keyboard or application::get_config().forward_mouse or application::get_config().forward_gamepad))
+			{
+				auto toast = gui_toast.lock();
+				toast->emplace(_("The server does not allow forwarded input devices"), true);
+				gui_status_last_change = instance.now();
+			}
 			return;
 		case wivrn::to_headset::feature_control::microphone:
 			if (audio_handle)
@@ -94,6 +98,7 @@ void scenes::stream::operator()(to_headset::feature_control && control)
 			return;
 	}
 }
+
 void scenes::stream::operator()(to_headset::audio_stream_description && desc)
 {
 	audio_handle.emplace(desc, *network_session, instance);

--- a/client/scenes/stream_tracking.cpp
+++ b/client/scenes/stream_tracking.cpp
@@ -443,6 +443,7 @@ void scenes::stream::tracking()
 			tracking.interaction_profiles = {
 			        interaction_profiles[0].load(),
 			        interaction_profiles[1].load(),
+			        interaction_profiles[2].load(),
 			};
 
 			tracking.production_timestamp = t0;
@@ -664,6 +665,7 @@ void scenes::stream::on_interaction_profile_changed(const XrEventDataInteraction
 	std::array path = {
 	        "/user/hand/left",
 	        "/user/hand/right",
+	        "/user/gamepad",
 	};
 #define DO_PROFILE(vendor, name)                                                \
 	if (profile == "/interaction_profiles/" #vendor "/" #name)              \
@@ -672,7 +674,7 @@ void scenes::stream::on_interaction_profile_changed(const XrEventDataInteraction
 		continue;                                                       \
 	}
 
-	for (size_t i = 0; i < 2; ++i)
+	for (size_t i = 0; i < path.size(); ++i)
 	{
 		try
 		{

--- a/common/wivrn_packets.h
+++ b/common/wivrn_packets.h
@@ -269,6 +269,10 @@ struct settings_changed
 
 	uint32_t fps_divider = 1;
 	uint32_t bitrate_bps;
+
+	// Whether the server should mirror the gamepad to a virtual uinput device;
+	// gamepad inputs are always forwarded for the OpenXR path
+	bool mirror_gamepad = false;
 };
 
 struct headset_info_packet

--- a/common/wivrn_packets.h
+++ b/common/wivrn_packets.h
@@ -43,96 +43,122 @@ static constexpr int protocol_revision = 2;
 
 enum class device_id : uint8_t
 {
-	HEAD,                     // /user/head
-	LEFT_CONTROLLER_HAPTIC,   // /user/hand/left/output/haptic
-	RIGHT_CONTROLLER_HAPTIC,  // /user/hand/right/output/haptic
-	LEFT_TRIGGER_HAPTIC,      // /user/hand/left/output/haptic_trigger
-	RIGHT_TRIGGER_HAPTIC,     // /user/hand/right/output/haptic_trigger
-	LEFT_THUMB_HAPTIC,        // /user/hand/left/output/haptic_thumb
-	RIGHT_THUMB_HAPTIC,       // /user/hand/right/output/haptic_thumb
-	LEFT_GRIP,                // /user/hand/left/input/grip/pose
-	LEFT_AIM,                 // /user/hand/left/input/aim/pose
-	LEFT_PALM,                // /user/hand/left/palm_ext/pose
-	RIGHT_GRIP,               // /user/hand/right/input/grip/pose
-	RIGHT_AIM,                // /user/hand/right/input/aim/pose
-	RIGHT_PALM,               // /user/hand/right/palm_ext/pose
-	X_CLICK,                  // /user/hand/left/input/x/click
-	X_TOUCH,                  // /user/hand/left/input/x/touch
-	Y_CLICK,                  // /user/hand/left/input/y/click
-	Y_TOUCH,                  // /user/hand/left/input/y/touch
-	MENU_CLICK,               // /user/hand/left/input/menu/click
-	LEFT_SQUEEZE_CLICK,       // /user/hand/left/input/squeeze/click
-	LEFT_SQUEEZE_FORCE,       // /user/hand/left/input/squeeze/force
-	LEFT_SQUEEZE_VALUE,       // /user/hand/left/input/squeeze/value
-	LEFT_TRIGGER_CLICK,       // /user/hand/left/input/trigger/click
-	LEFT_TRIGGER_VALUE,       // /user/hand/left/input/trigger/value
-	LEFT_TRIGGER_TOUCH,       // /user/hand/left/input/trigger/touch
-	LEFT_TRIGGER_PROXIMITY,   // /user/hand/left/input/trigger/proximity
-	LEFT_TRIGGER_CURL,        // /user/hand/left/input/trigger/curl_fb
-	LEFT_TRIGGER_SLIDE,       // /user/hand/left/input/trigger/slide_fb
-	LEFT_TRIGGER_FORCE,       // /user/hand/left/input/trigger/force
-	LEFT_THUMBSTICK_X,        // /user/hand/left/input/thumbstick/x
-	LEFT_THUMBSTICK_Y,        // /user/hand/left/input/thumbstick/y
-	LEFT_THUMBSTICK_CLICK,    // /user/hand/left/input/thumbstick/click
-	LEFT_THUMBSTICK_TOUCH,    // /user/hand/left/input/thumbstick/touch
-	LEFT_THUMBREST_TOUCH,     // /user/hand/left/input/thumbrest/touch
-	LEFT_THUMBREST_FORCE,     // /user/hand/left/input/thumbrest/force
-	LEFT_THUMB_PROXIMITY,     // /user/hand/left/input/thumb_resting_surfaces/proximity
-	LEFT_TRACKPAD_X,          // /user/hand/left/input/trackpad/x
-	LEFT_TRACKPAD_Y,          // /user/hand/left/input/trackpad/y
-	LEFT_TRACKPAD_CLICK,      // /user/hand/left/input/trackpad/click
-	LEFT_TRACKPAD_TOUCH,      // /user/hand/left/input/trackpad/touch
-	LEFT_TRACKPAD_FORCE,      // /user/hand/left/input/trackpad/force
-	LEFT_STYLUS_FORCE,        // /user/hand/left/input/stylus_fb/force
-	LEFT_PINCH_POSE,          // /user/hand/left/input/pinch_ext/pose
-	LEFT_PINCH_VALUE,         // /user/hand/left/input/pinch_ext/value
-	LEFT_PINCH_READY,         // /user/hand/left/input/pinch_ext/ready_ext
-	LEFT_POKE,                // /user/hand/left/input/poke_ext/pose
-	LEFT_AIM_ACTIVATE_VALUE,  // /user/hand/left/input/aim_activate_ext/value
-	LEFT_AIM_ACTIVATE_READY,  // /user/hand/left/input/aim_activate_ext/ready_ext
-	LEFT_GRASP_VALUE,         // /user/hand/left/input/grasp_ext/value
-	LEFT_GRASP_READY,         // /user/hand/left/input/grasp_ext/ready_ext
-	A_CLICK,                  // /user/hand/right/input/a/click
-	A_TOUCH,                  // /user/hand/right/input/a/touch
-	B_CLICK,                  // /user/hand/right/input/b/click
-	B_TOUCH,                  // /user/hand/right/input/b/touch
-	SYSTEM_CLICK,             // /user/hand/right/input/system/click
-	RIGHT_SQUEEZE_CLICK,      // /user/hand/right/input/squeeze/click
-	RIGHT_SQUEEZE_FORCE,      // /user/hand/right/input/squeeze/force
-	RIGHT_SQUEEZE_VALUE,      // /user/hand/right/input/squeeze/value
-	RIGHT_TRIGGER_CLICK,      // /user/hand/right/input/trigger/click
-	RIGHT_TRIGGER_VALUE,      // /user/hand/right/input/trigger/value
-	RIGHT_TRIGGER_TOUCH,      // /user/hand/right/input/trigger/touch
-	RIGHT_TRIGGER_PROXIMITY,  // /user/hand/right/input/trigger/proximity
-	RIGHT_TRIGGER_CURL,       // /user/hand/right/input/trigger/curl_fb
-	RIGHT_TRIGGER_SLIDE,      // /user/hand/right/input/trigger/slide_fb
-	RIGHT_TRIGGER_FORCE,      // /user/hand/right/input/trigger/force
-	RIGHT_THUMBSTICK_X,       // /user/hand/right/input/thumbstick/x
-	RIGHT_THUMBSTICK_Y,       // /user/hand/right/input/thumbstick/y
-	RIGHT_THUMBSTICK_CLICK,   // /user/hand/right/input/thumbstick/click
-	RIGHT_THUMBSTICK_TOUCH,   // /user/hand/right/input/thumbstick/touch
-	RIGHT_THUMBREST_TOUCH,    // /user/hand/right/input/thumbrest/touch
-	RIGHT_THUMBREST_FORCE,    // /user/hand/right/input/thumbrest/force
-	RIGHT_THUMB_PROXIMITY,    // /user/hand/right/input/thumb_resting_surfaces/proximity
-	RIGHT_TRACKPAD_X,         // /user/hand/right/input/trackpad/x
-	RIGHT_TRACKPAD_Y,         // /user/hand/right/input/trackpad/y
-	RIGHT_TRACKPAD_CLICK,     // /user/hand/right/input/trackpad/click
-	RIGHT_TRACKPAD_TOUCH,     // /user/hand/right/input/trackpad/touch
-	RIGHT_TRACKPAD_FORCE,     // /user/hand/right/input/trackpad/force
-	RIGHT_STYLUS_FORCE,       // /user/hand/right/input/stylus_fb/force
-	RIGHT_PINCH_POSE,         // /user/hand/right/input/pinch_ext/pose
-	RIGHT_PINCH_VALUE,        // /user/hand/right/input/pinch_ext/value
-	RIGHT_PINCH_READY,        // /user/hand/right/input/pinch_ext/ready_ext
-	RIGHT_POKE,               // /user/hand/right/input/poke_ext/pose
-	RIGHT_AIM_ACTIVATE_VALUE, // /user/hand/right/input/aim_activate_ext/value
-	RIGHT_AIM_ACTIVATE_READY, // /user/hand/right/input/aim_activate_ext/ready_ext
-	RIGHT_GRASP_VALUE,        // /user/hand/right/input/grasp_ext/value
-	RIGHT_GRASP_READY,        // /user/hand/right/input/grasp_ext/ready_ext
-	EYE_GAZE,                 // /user/eyes_ext/input/gaze_ext/pose
-	LEFT_HAND,                // identify hand tracking
-	RIGHT_HAND,               // identify hand tracking
-	BODY,                     // identify body tracking
-	FACE,                     // identify face tracking
+	HEAD,                         // /user/head
+	LEFT_CONTROLLER_HAPTIC,       // /user/hand/left/output/haptic
+	RIGHT_CONTROLLER_HAPTIC,      // /user/hand/right/output/haptic
+	LEFT_TRIGGER_HAPTIC,          // /user/hand/left/output/haptic_trigger
+	RIGHT_TRIGGER_HAPTIC,         // /user/hand/right/output/haptic_trigger
+	LEFT_THUMB_HAPTIC,            // /user/hand/left/output/haptic_thumb
+	RIGHT_THUMB_HAPTIC,           // /user/hand/right/output/haptic_thumb
+	GAMEPAD_HAPTIC_LEFT,          // /user/gamepad/output/haptic_left
+	GAMEPAD_HAPTIC_RIGHT,         // /user/gamepad/output/haptic_right
+	GAMEPAD_HAPTIC_LEFT_TRIGGER,  // /user/gamepad/output/haptic_left_trigger
+	GAMEPAD_HAPTIC_RIGHT_TRIGGER, // /user/gamepad/output/haptic_right_trigger
+	LEFT_GRIP,                    // /user/hand/left/input/grip/pose
+	LEFT_AIM,                     // /user/hand/left/input/aim/pose
+	LEFT_PALM,                    // /user/hand/left/palm_ext/pose
+	RIGHT_GRIP,                   // /user/hand/right/input/grip/pose
+	RIGHT_AIM,                    // /user/hand/right/input/aim/pose
+	RIGHT_PALM,                   // /user/hand/right/palm_ext/pose
+	X_CLICK,                      // /user/hand/left/input/x/click
+	X_TOUCH,                      // /user/hand/left/input/x/touch
+	Y_CLICK,                      // /user/hand/left/input/y/click
+	Y_TOUCH,                      // /user/hand/left/input/y/touch
+	MENU_CLICK,                   // /user/hand/left/input/menu/click
+	LEFT_SQUEEZE_CLICK,           // /user/hand/left/input/squeeze/click
+	LEFT_SQUEEZE_FORCE,           // /user/hand/left/input/squeeze/force
+	LEFT_SQUEEZE_VALUE,           // /user/hand/left/input/squeeze/value
+	LEFT_TRIGGER_CLICK,           // /user/hand/left/input/trigger/click
+	LEFT_TRIGGER_VALUE,           // /user/hand/left/input/trigger/value
+	LEFT_TRIGGER_TOUCH,           // /user/hand/left/input/trigger/touch
+	LEFT_TRIGGER_PROXIMITY,       // /user/hand/left/input/trigger/proximity
+	LEFT_TRIGGER_CURL,            // /user/hand/left/input/trigger/curl_fb
+	LEFT_TRIGGER_SLIDE,           // /user/hand/left/input/trigger/slide_fb
+	LEFT_TRIGGER_FORCE,           // /user/hand/left/input/trigger/force
+	LEFT_THUMBSTICK_X,            // /user/hand/left/input/thumbstick/x
+	LEFT_THUMBSTICK_Y,            // /user/hand/left/input/thumbstick/y
+	LEFT_THUMBSTICK_CLICK,        // /user/hand/left/input/thumbstick/click
+	LEFT_THUMBSTICK_TOUCH,        // /user/hand/left/input/thumbstick/touch
+	LEFT_THUMBREST_TOUCH,         // /user/hand/left/input/thumbrest/touch
+	LEFT_THUMBREST_FORCE,         // /user/hand/left/input/thumbrest/force
+	LEFT_THUMB_PROXIMITY,         // /user/hand/left/input/thumb_resting_surfaces/proximity
+	LEFT_TRACKPAD_X,              // /user/hand/left/input/trackpad/x
+	LEFT_TRACKPAD_Y,              // /user/hand/left/input/trackpad/y
+	LEFT_TRACKPAD_CLICK,          // /user/hand/left/input/trackpad/click
+	LEFT_TRACKPAD_TOUCH,          // /user/hand/left/input/trackpad/touch
+	LEFT_TRACKPAD_FORCE,          // /user/hand/left/input/trackpad/force
+	LEFT_STYLUS_FORCE,            // /user/hand/left/input/stylus_fb/force
+	LEFT_PINCH_POSE,              // /user/hand/left/input/pinch_ext/pose
+	LEFT_PINCH_VALUE,             // /user/hand/left/input/pinch_ext/value
+	LEFT_PINCH_READY,             // /user/hand/left/input/pinch_ext/ready_ext
+	LEFT_POKE,                    // /user/hand/left/input/poke_ext/pose
+	LEFT_AIM_ACTIVATE_VALUE,      // /user/hand/left/input/aim_activate_ext/value
+	LEFT_AIM_ACTIVATE_READY,      // /user/hand/left/input/aim_activate_ext/ready_ext
+	LEFT_GRASP_VALUE,             // /user/hand/left/input/grasp_ext/value
+	LEFT_GRASP_READY,             // /user/hand/left/input/grasp_ext/ready_ext
+	A_CLICK,                      // /user/hand/right/input/a/click
+	A_TOUCH,                      // /user/hand/right/input/a/touch
+	B_CLICK,                      // /user/hand/right/input/b/click
+	B_TOUCH,                      // /user/hand/right/input/b/touch
+	SYSTEM_CLICK,                 // /user/hand/right/input/system/click
+	RIGHT_SQUEEZE_CLICK,          // /user/hand/right/input/squeeze/click
+	RIGHT_SQUEEZE_FORCE,          // /user/hand/right/input/squeeze/force
+	RIGHT_SQUEEZE_VALUE,          // /user/hand/right/input/squeeze/value
+	RIGHT_TRIGGER_CLICK,          // /user/hand/right/input/trigger/click
+	RIGHT_TRIGGER_VALUE,          // /user/hand/right/input/trigger/value
+	RIGHT_TRIGGER_TOUCH,          // /user/hand/right/input/trigger/touch
+	RIGHT_TRIGGER_PROXIMITY,      // /user/hand/right/input/trigger/proximity
+	RIGHT_TRIGGER_CURL,           // /user/hand/right/input/trigger/curl_fb
+	RIGHT_TRIGGER_SLIDE,          // /user/hand/right/input/trigger/slide_fb
+	RIGHT_TRIGGER_FORCE,          // /user/hand/right/input/trigger/force
+	RIGHT_THUMBSTICK_X,           // /user/hand/right/input/thumbstick/x
+	RIGHT_THUMBSTICK_Y,           // /user/hand/right/input/thumbstick/y
+	RIGHT_THUMBSTICK_CLICK,       // /user/hand/right/input/thumbstick/click
+	RIGHT_THUMBSTICK_TOUCH,       // /user/hand/right/input/thumbstick/touch
+	RIGHT_THUMBREST_TOUCH,        // /user/hand/right/input/thumbrest/touch
+	RIGHT_THUMBREST_FORCE,        // /user/hand/right/input/thumbrest/force
+	RIGHT_THUMB_PROXIMITY,        // /user/hand/right/input/thumb_resting_surfaces/proximity
+	RIGHT_TRACKPAD_X,             // /user/hand/right/input/trackpad/x
+	RIGHT_TRACKPAD_Y,             // /user/hand/right/input/trackpad/y
+	RIGHT_TRACKPAD_CLICK,         // /user/hand/right/input/trackpad/click
+	RIGHT_TRACKPAD_TOUCH,         // /user/hand/right/input/trackpad/touch
+	RIGHT_TRACKPAD_FORCE,         // /user/hand/right/input/trackpad/force
+	RIGHT_STYLUS_FORCE,           // /user/hand/right/input/stylus_fb/force
+	RIGHT_PINCH_POSE,             // /user/hand/right/input/pinch_ext/pose
+	RIGHT_PINCH_VALUE,            // /user/hand/right/input/pinch_ext/value
+	RIGHT_PINCH_READY,            // /user/hand/right/input/pinch_ext/ready_ext
+	RIGHT_POKE,                   // /user/hand/right/input/poke_ext/pose
+	RIGHT_AIM_ACTIVATE_VALUE,     // /user/hand/right/input/aim_activate_ext/value
+	RIGHT_AIM_ACTIVATE_READY,     // /user/hand/right/input/aim_activate_ext/ready_ext
+	RIGHT_GRASP_VALUE,            // /user/hand/right/input/grasp_ext/value
+	RIGHT_GRASP_READY,            // /user/hand/right/input/grasp_ext/ready_ext
+	EYE_GAZE,                     // /user/eyes_ext/input/gaze_ext/pose
+	LEFT_HAND,                    // identify hand tracking
+	RIGHT_HAND,                   // identify hand tracking
+	BODY,                         // identify body tracking
+	FACE,                         // identify face tracking
+
+	// Gamepad, microsoft/xbox_controller profile (/user/gamepad)
+	GAMEPAD_MENU_CLICK,             // /user/gamepad/input/menu/click
+	GAMEPAD_VIEW_CLICK,             // /user/gamepad/input/view/click
+	GAMEPAD_A_CLICK,                // /user/gamepad/input/a/click
+	GAMEPAD_B_CLICK,                // /user/gamepad/input/b/click
+	GAMEPAD_X_CLICK,                // /user/gamepad/input/x/click
+	GAMEPAD_Y_CLICK,                // /user/gamepad/input/y/click
+	GAMEPAD_DPAD_DOWN_CLICK,        // /user/gamepad/input/dpad_down/click
+	GAMEPAD_DPAD_RIGHT_CLICK,       // /user/gamepad/input/dpad_right/click
+	GAMEPAD_DPAD_UP_CLICK,          // /user/gamepad/input/dpad_up/click
+	GAMEPAD_DPAD_LEFT_CLICK,        // /user/gamepad/input/dpad_left/click
+	GAMEPAD_SHOULDER_LEFT_CLICK,    // /user/gamepad/input/shoulder_left/click
+	GAMEPAD_SHOULDER_RIGHT_CLICK,   // /user/gamepad/input/shoulder_right/click
+	GAMEPAD_THUMBSTICK_LEFT_CLICK,  // /user/gamepad/input/thumbstick_left/click
+	GAMEPAD_THUMBSTICK_RIGHT_CLICK, // /user/gamepad/input/thumbstick_right/click
+	GAMEPAD_TRIGGER_LEFT_VALUE,     // /user/gamepad/input/trigger_left/value
+	GAMEPAD_TRIGGER_RIGHT_VALUE,    // /user/gamepad/input/trigger_right/value
+	GAMEPAD_THUMBSTICK_LEFT_X,      // /user/gamepad/input/thumbstick_left/x
+	GAMEPAD_THUMBSTICK_LEFT_Y,      // /user/gamepad/input/thumbstick_left/y
+	GAMEPAD_THUMBSTICK_RIGHT_X,     // /user/gamepad/input/thumbstick_right/x
+	GAMEPAD_THUMBSTICK_RIGHT_Y,     // /user/gamepad/input/thumbstick_right/y
 };
 
 enum class interaction_profile : uint8_t
@@ -319,8 +345,8 @@ struct tracking
 		XrFovf fov;
 	};
 
-	// /user/hand/left and /user/hand/right
-	std::array<interaction_profile, 2> interaction_profiles;
+	// /user/hand/left, /user/hand/right and /user/gamepad
+	std::array<interaction_profile, 3> interaction_profiles;
 
 	XrTime production_timestamp;
 	XrTime timestamp;

--- a/dashboard/qml/SettingsPage.qml
+++ b/dashboard/qml/SettingsPage.qml
@@ -111,10 +111,10 @@ Kirigami.ScrollablePage {
                 visible: Settings.hid_forwarding_supported
                 Controls.CheckBox {
                     id: hid_forwarding
-                    text: i18n("Forward keyboard & mouse from headset")
+                    text: i18n("Expose forwarded input devices via uinput")
                 }
                 Kirigami.ContextualHelpButton {
-                    toolTipText: i18n("Keyboard and mouse connected to the client will act as if connected to the server. Client OS may reserve specific keys and combinations, which cannot be forwarded.")
+                    toolTipText: i18n("Replicate mouse, keyboard and gamepad connected to the headset as virtual devices on PC.\nReplicated devices will appear as if they were plugged to the PC, some keys may be reserved by the headset OS and not be available. Gamepad is also available without virtual devices for applications that access it through OpenXR.")
                 }
             }
             Controls.CheckBox {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -136,7 +136,14 @@ Default value: `false`
 
 Only available when the `uinput` kernel module is loaded and the user has write access.
 
-Enables the forwarding of keyboard and mouse input from the client to the server.
+Mirrors input devices forwarded from the headset (keyboard, mouse, gamepad) to `uinput`
+devices, for applications that do not read them through OpenXR. Which devices are forwarded is
+chosen on the headset.
+
+A forwarded gamepad is also exposed as a native OpenXR gamepad at `/user/gamepad`, which needs
+no permission and is always available. Only the digested controller state is forwarded
+(buttons, two sticks, analog triggers and a d-pad), so device specific features such as gyro,
+adaptive triggers or the touchpad are not available.
 
 ## `debug-gui`
 Default value: `false`

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -123,6 +123,7 @@ if (WIVRN_BUILD_SERVER)
 			driver/wivrn_hmd.cpp
 			driver/wivrn_controller.cpp
 			driver/wivrn_eye_tracker.cpp
+			driver/wivrn_gamepad.cpp
 			driver/wivrn_android_face_tracker.cpp
 			driver/wivrn_fb_face2_tracker.cpp
 			driver/wivrn_htc_face_tracker.cpp

--- a/server/driver/configuration.cpp
+++ b/server/driver/configuration.cpp
@@ -189,6 +189,8 @@ configuration::configuration()
 			}
 		}
 
+		// Gates the uinput mirror of forwarded input devices. The OpenXR gamepad needs no
+		// permission, so it is always exposed.
 		if (auto it = json.find("hid-forwarding"); it != json.end())
 			hid_forwarding = *it;
 

--- a/server/driver/wivrn_controller.cpp
+++ b/server/driver/wivrn_controller.cpp
@@ -757,6 +757,9 @@ void wivrn_controller::set_inputs(const from_headset::inputs & inputs, const clo
 
 	for (const auto & input: inputs.values)
 	{
+		// Gamepad inputs are handled by wivrn_gamepad
+		if (input.id >= device_id::GAMEPAD_MENU_CLICK)
+			continue;
 		int64_t last_change_time = input.last_change_time ? clock_offset.from_headset(input.last_change_time) : 0;
 		auto [index, type, device] = map_input(input.id);
 		if (device != device_type)

--- a/server/driver/wivrn_gamepad.cpp
+++ b/server/driver/wivrn_gamepad.cpp
@@ -1,0 +1,185 @@
+/*
+ * WiVRn VR streaming
+ * Copyright (C) 2026  JR Lanteigne <root@dnim.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "wivrn_gamepad.h"
+
+#include "wivrn_gamepad_map.h"
+#include "wivrn_session.h"
+
+#include "xrt/xrt_defines.h"
+#include "xrt/xrt_device.h"
+
+#include "os/os_time.h"
+#include "util/u_logging.h"
+#include "utils/method.h"
+
+namespace wivrn
+{
+
+static_assert(gp_count == 18);
+
+wivrn_gamepad::wivrn_gamepad(wivrn::wivrn_session & cnx) :
+        xrt_device{
+                .name = XRT_DEVICE_XBOX_CONTROLLER,
+                .device_type = XRT_DEVICE_TYPE_GAMEPAD,
+                .str = "WiVRn Gamepad",
+                .serial = "WiVRn Gamepad",
+                .tracking_origin = &origin,
+                .update_inputs = method_pointer<&wivrn_gamepad::update_inputs>,
+                .get_tracked_pose = method_pointer<&wivrn_gamepad::get_tracked_pose>,
+                .set_output = method_pointer<&wivrn_gamepad::set_output>,
+                .destroy = [](xrt_device *) {},
+        },
+        origin{
+                .type = XRT_TRACKING_TYPE_OTHER,
+                .initial_offset = XRT_POSE_IDENTITY,
+        },
+        cnx(&cnx)
+{
+	inputs_array = {};
+	inputs_staging = {};
+	inputs = inputs_array.data();
+	input_count = inputs_array.size();
+
+	inputs_array[gp_menu].name = XRT_INPUT_XBOX_MENU_CLICK;
+	inputs_array[gp_view].name = XRT_INPUT_XBOX_VIEW_CLICK;
+	inputs_array[gp_a].name = XRT_INPUT_XBOX_A_CLICK;
+	inputs_array[gp_b].name = XRT_INPUT_XBOX_B_CLICK;
+	inputs_array[gp_x].name = XRT_INPUT_XBOX_X_CLICK;
+	inputs_array[gp_y].name = XRT_INPUT_XBOX_Y_CLICK;
+	inputs_array[gp_dpad_down].name = XRT_INPUT_XBOX_DPAD_DOWN_CLICK;
+	inputs_array[gp_dpad_right].name = XRT_INPUT_XBOX_DPAD_RIGHT_CLICK;
+	inputs_array[gp_dpad_up].name = XRT_INPUT_XBOX_DPAD_UP_CLICK;
+	inputs_array[gp_dpad_left].name = XRT_INPUT_XBOX_DPAD_LEFT_CLICK;
+	inputs_array[gp_shoulder_left].name = XRT_INPUT_XBOX_SHOULDER_LEFT_CLICK;
+	inputs_array[gp_shoulder_right].name = XRT_INPUT_XBOX_SHOULDER_RIGHT_CLICK;
+	inputs_array[gp_thumbstick_left_click].name = XRT_INPUT_XBOX_THUMBSTICK_LEFT_CLICK;
+	inputs_array[gp_thumbstick_right_click].name = XRT_INPUT_XBOX_THUMBSTICK_RIGHT_CLICK;
+	inputs_array[gp_thumbstick_left].name = XRT_INPUT_XBOX_THUMBSTICK_LEFT;
+	inputs_array[gp_thumbstick_right].name = XRT_INPUT_XBOX_THUMBSTICK_RIGHT;
+	inputs_array[gp_trigger_left].name = XRT_INPUT_XBOX_LEFT_TRIGGER_VALUE;
+	inputs_array[gp_trigger_right].name = XRT_INPUT_XBOX_RIGHT_TRIGGER_VALUE;
+
+	outputs_array = {{
+	        {.name = XRT_OUTPUT_NAME_XBOX_HAPTIC_LEFT},
+	        {.name = XRT_OUTPUT_NAME_XBOX_HAPTIC_RIGHT},
+	        {.name = XRT_OUTPUT_NAME_XBOX_HAPTIC_LEFT_TRIGGER},
+	        {.name = XRT_OUTPUT_NAME_XBOX_HAPTIC_RIGHT_TRIGGER},
+	}};
+	output_count = outputs_array.size();
+	outputs = outputs_array.data();
+}
+
+xrt_result_t wivrn_gamepad::update_inputs()
+{
+	std::lock_guard lock(mutex);
+
+	const int64_t timestamp = os_monotonic_get_ns();
+	for (size_t i = 0; i < inputs_array.size(); ++i)
+	{
+		inputs_array[i].value = inputs_staging[i].value;
+		inputs_array[i].active = connected;
+		inputs_array[i].timestamp = timestamp;
+	}
+
+	return XRT_SUCCESS;
+}
+
+xrt_result_t wivrn_gamepad::get_tracked_pose(xrt_input_name name, int64_t, xrt_space_relation * out_relation)
+{
+	// A gamepad has no tracked pose.
+	*out_relation = {};
+	U_LOG_XDEV_UNSUPPORTED_INPUT(this, u_log_get_global_level(), name);
+	return XRT_ERROR_INPUT_UNSUPPORTED;
+}
+
+void wivrn_gamepad::set_inputs(const from_headset::inputs & inputs)
+{
+	std::lock_guard lock(mutex);
+
+	for (const auto & value: inputs.values)
+	{
+		auto m = map_gamepad(value.id);
+		if (m.slot == gp_count)
+			continue;
+		auto & v = inputs_staging[m.slot].value;
+		switch (m.kind)
+		{
+			case gp_value::button:
+			case gp_value::dpad:
+				v.boolean = value.value != 0;
+				break;
+			case gp_value::trigger:
+				v.vec1.x = value.value;
+				break;
+			case gp_value::stick_x:
+				v.vec2.x = value.value;
+				break;
+			case gp_value::stick_y:
+				v.vec2.y = value.value;
+				break;
+		}
+	}
+}
+
+xrt_result_t wivrn_gamepad::set_output(xrt_output_name name, const xrt_output_value * value)
+{
+	device_id id;
+	switch (name)
+	{
+		case XRT_OUTPUT_NAME_XBOX_HAPTIC_LEFT:
+			id = device_id::GAMEPAD_HAPTIC_LEFT;
+			break;
+		case XRT_OUTPUT_NAME_XBOX_HAPTIC_RIGHT:
+			id = device_id::GAMEPAD_HAPTIC_RIGHT;
+			break;
+		case XRT_OUTPUT_NAME_XBOX_HAPTIC_LEFT_TRIGGER:
+			id = device_id::GAMEPAD_HAPTIC_LEFT_TRIGGER;
+			break;
+		case XRT_OUTPUT_NAME_XBOX_HAPTIC_RIGHT_TRIGGER:
+			id = device_id::GAMEPAD_HAPTIC_RIGHT_TRIGGER;
+			break;
+		default:
+			return XRT_ERROR_OUTPUT_UNSUPPORTED;
+	}
+
+	try
+	{
+		cnx->send_stream(to_headset::haptics{
+		        .id = id,
+		        .duration = std::chrono::nanoseconds(value->vibration.duration_ns),
+		        .frequency = value->vibration.frequency,
+		        .amplitude = value->vibration.amplitude});
+	}
+	catch (...)
+	{
+		return XRT_ERROR_OUTPUT_REQUEST_FAILURE;
+	}
+	return XRT_SUCCESS;
+}
+
+void wivrn_gamepad::set_connected(bool value)
+{
+	std::lock_guard lock(mutex);
+	connected = value;
+	if (not connected)
+		for (auto & input: inputs_staging)
+			input.value = {};
+}
+
+} // namespace wivrn

--- a/server/driver/wivrn_gamepad.h
+++ b/server/driver/wivrn_gamepad.h
@@ -1,0 +1,61 @@
+/*
+ * WiVRn VR streaming
+ * Copyright (C) 2026  JR Lanteigne <root@dnim.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "wivrn_packets.h"
+
+#include "xrt/xrt_defines.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_tracking.h"
+
+#include <array>
+#include <mutex>
+
+namespace wivrn
+{
+class wivrn_session;
+
+// A gamepad forwarded from the headset, exposed as an OpenXR xbox_controller (/user/gamepad).
+// Inputs stay inactive until the headset reports a gamepad is connected.
+class wivrn_gamepad : public xrt_device
+{
+	std::mutex mutex;
+	bool connected = false;
+
+	xrt_tracking_origin origin;
+	std::array<xrt_input, 18> inputs_array;
+	std::array<xrt_input, 18> inputs_staging; // written from the network thread, published by update_inputs
+	std::array<xrt_output, 4> outputs_array;
+
+	wivrn::wivrn_session * cnx;
+
+public:
+	using base_t = xrt_device;
+	wivrn_gamepad(wivrn::wivrn_session & cnx);
+
+	xrt_result_t update_inputs();
+	xrt_result_t get_tracked_pose(xrt_input_name name, int64_t at_timestamp_ns, xrt_space_relation * out_relation);
+	xrt_result_t set_output(xrt_output_name name, const xrt_output_value * value);
+
+	// Update from a forwarded inputs packet (gamepad device_ids).
+	void set_inputs(const from_headset::inputs &);
+	void set_connected(bool);
+};
+
+} // namespace wivrn

--- a/server/driver/wivrn_gamepad_map.h
+++ b/server/driver/wivrn_gamepad_map.h
@@ -20,6 +20,9 @@
 
 #include "wivrn_packets.h"
 
+#include <cstdint>
+#include <linux/input-event-codes.h>
+
 namespace wivrn
 {
 enum gp_input
@@ -58,6 +61,7 @@ struct gamepad_input
 {
 	gp_input slot;
 	gp_value kind;
+	uint16_t ev_code; // BTN_* or ABS_*, unused for dpad
 };
 
 inline gamepad_input map_gamepad(device_id id)
@@ -65,47 +69,49 @@ inline gamepad_input map_gamepad(device_id id)
 	switch (id)
 	{
 		case device_id::GAMEPAD_MENU_CLICK:
-			return {gp_menu, gp_value::button};
+			return {gp_menu, gp_value::button, BTN_START};
 		case device_id::GAMEPAD_VIEW_CLICK:
-			return {gp_view, gp_value::button};
+			return {gp_view, gp_value::button, BTN_SELECT};
 		case device_id::GAMEPAD_A_CLICK:
-			return {gp_a, gp_value::button};
+			return {gp_a, gp_value::button, BTN_SOUTH};
 		case device_id::GAMEPAD_B_CLICK:
-			return {gp_b, gp_value::button};
+			return {gp_b, gp_value::button, BTN_EAST};
+		// BTN_X/BTN_Y aliases don't match compass positions (BTN_X == BTN_NORTH,
+		// BTN_Y == BTN_WEST); xpad and SDL expect the aliases, not the positions
 		case device_id::GAMEPAD_X_CLICK:
-			return {gp_x, gp_value::button};
+			return {gp_x, gp_value::button, BTN_X};
 		case device_id::GAMEPAD_Y_CLICK:
-			return {gp_y, gp_value::button};
+			return {gp_y, gp_value::button, BTN_Y};
 		case device_id::GAMEPAD_SHOULDER_LEFT_CLICK:
-			return {gp_shoulder_left, gp_value::button};
+			return {gp_shoulder_left, gp_value::button, BTN_TL};
 		case device_id::GAMEPAD_SHOULDER_RIGHT_CLICK:
-			return {gp_shoulder_right, gp_value::button};
+			return {gp_shoulder_right, gp_value::button, BTN_TR};
 		case device_id::GAMEPAD_THUMBSTICK_LEFT_CLICK:
-			return {gp_thumbstick_left_click, gp_value::button};
+			return {gp_thumbstick_left_click, gp_value::button, BTN_THUMBL};
 		case device_id::GAMEPAD_THUMBSTICK_RIGHT_CLICK:
-			return {gp_thumbstick_right_click, gp_value::button};
+			return {gp_thumbstick_right_click, gp_value::button, BTN_THUMBR};
 		case device_id::GAMEPAD_DPAD_DOWN_CLICK:
-			return {gp_dpad_down, gp_value::dpad};
+			return {gp_dpad_down, gp_value::dpad, 0};
 		case device_id::GAMEPAD_DPAD_RIGHT_CLICK:
-			return {gp_dpad_right, gp_value::dpad};
+			return {gp_dpad_right, gp_value::dpad, 0};
 		case device_id::GAMEPAD_DPAD_UP_CLICK:
-			return {gp_dpad_up, gp_value::dpad};
+			return {gp_dpad_up, gp_value::dpad, 0};
 		case device_id::GAMEPAD_DPAD_LEFT_CLICK:
-			return {gp_dpad_left, gp_value::dpad};
+			return {gp_dpad_left, gp_value::dpad, 0};
 		case device_id::GAMEPAD_TRIGGER_LEFT_VALUE:
-			return {gp_trigger_left, gp_value::trigger};
+			return {gp_trigger_left, gp_value::trigger, ABS_Z};
 		case device_id::GAMEPAD_TRIGGER_RIGHT_VALUE:
-			return {gp_trigger_right, gp_value::trigger};
+			return {gp_trigger_right, gp_value::trigger, ABS_RZ};
 		case device_id::GAMEPAD_THUMBSTICK_LEFT_X:
-			return {gp_thumbstick_left, gp_value::stick_x};
+			return {gp_thumbstick_left, gp_value::stick_x, ABS_X};
 		case device_id::GAMEPAD_THUMBSTICK_LEFT_Y:
-			return {gp_thumbstick_left, gp_value::stick_y};
+			return {gp_thumbstick_left, gp_value::stick_y, ABS_Y};
 		case device_id::GAMEPAD_THUMBSTICK_RIGHT_X:
-			return {gp_thumbstick_right, gp_value::stick_x};
+			return {gp_thumbstick_right, gp_value::stick_x, ABS_RX};
 		case device_id::GAMEPAD_THUMBSTICK_RIGHT_Y:
-			return {gp_thumbstick_right, gp_value::stick_y};
+			return {gp_thumbstick_right, gp_value::stick_y, ABS_RY};
 		default:
-			return {gp_count, gp_value::button};
+			return {gp_count, gp_value::button, 0};
 	}
 }
 

--- a/server/driver/wivrn_gamepad_map.h
+++ b/server/driver/wivrn_gamepad_map.h
@@ -1,0 +1,112 @@
+/*
+ * WiVRn VR streaming
+ * Copyright (C) 2026  JR Lanteigne <root@dnim.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "wivrn_packets.h"
+
+namespace wivrn
+{
+enum gp_input
+{
+	gp_menu,
+	gp_view,
+	gp_a,
+	gp_b,
+	gp_x,
+	gp_y,
+	gp_dpad_down,
+	gp_dpad_right,
+	gp_dpad_up,
+	gp_dpad_left,
+	gp_shoulder_left,
+	gp_shoulder_right,
+	gp_thumbstick_left_click,
+	gp_thumbstick_right_click,
+	gp_thumbstick_left,
+	gp_thumbstick_right,
+	gp_trigger_left,
+	gp_trigger_right,
+	gp_count,
+};
+
+enum class gp_value
+{
+	button,
+	dpad,
+	trigger,
+	stick_x,
+	stick_y,
+};
+
+struct gamepad_input
+{
+	gp_input slot;
+	gp_value kind;
+};
+
+inline gamepad_input map_gamepad(device_id id)
+{
+	switch (id)
+	{
+		case device_id::GAMEPAD_MENU_CLICK:
+			return {gp_menu, gp_value::button};
+		case device_id::GAMEPAD_VIEW_CLICK:
+			return {gp_view, gp_value::button};
+		case device_id::GAMEPAD_A_CLICK:
+			return {gp_a, gp_value::button};
+		case device_id::GAMEPAD_B_CLICK:
+			return {gp_b, gp_value::button};
+		case device_id::GAMEPAD_X_CLICK:
+			return {gp_x, gp_value::button};
+		case device_id::GAMEPAD_Y_CLICK:
+			return {gp_y, gp_value::button};
+		case device_id::GAMEPAD_SHOULDER_LEFT_CLICK:
+			return {gp_shoulder_left, gp_value::button};
+		case device_id::GAMEPAD_SHOULDER_RIGHT_CLICK:
+			return {gp_shoulder_right, gp_value::button};
+		case device_id::GAMEPAD_THUMBSTICK_LEFT_CLICK:
+			return {gp_thumbstick_left_click, gp_value::button};
+		case device_id::GAMEPAD_THUMBSTICK_RIGHT_CLICK:
+			return {gp_thumbstick_right_click, gp_value::button};
+		case device_id::GAMEPAD_DPAD_DOWN_CLICK:
+			return {gp_dpad_down, gp_value::dpad};
+		case device_id::GAMEPAD_DPAD_RIGHT_CLICK:
+			return {gp_dpad_right, gp_value::dpad};
+		case device_id::GAMEPAD_DPAD_UP_CLICK:
+			return {gp_dpad_up, gp_value::dpad};
+		case device_id::GAMEPAD_DPAD_LEFT_CLICK:
+			return {gp_dpad_left, gp_value::dpad};
+		case device_id::GAMEPAD_TRIGGER_LEFT_VALUE:
+			return {gp_trigger_left, gp_value::trigger};
+		case device_id::GAMEPAD_TRIGGER_RIGHT_VALUE:
+			return {gp_trigger_right, gp_value::trigger};
+		case device_id::GAMEPAD_THUMBSTICK_LEFT_X:
+			return {gp_thumbstick_left, gp_value::stick_x};
+		case device_id::GAMEPAD_THUMBSTICK_LEFT_Y:
+			return {gp_thumbstick_left, gp_value::stick_y};
+		case device_id::GAMEPAD_THUMBSTICK_RIGHT_X:
+			return {gp_thumbstick_right, gp_value::stick_x};
+		case device_id::GAMEPAD_THUMBSTICK_RIGHT_Y:
+			return {gp_thumbstick_right, gp_value::stick_y};
+		default:
+			return {gp_count, gp_value::button};
+	}
+}
+
+} // namespace wivrn

--- a/server/driver/wivrn_session.cpp
+++ b/server/driver/wivrn_session.cpp
@@ -248,10 +248,10 @@ wivrn::wivrn_session::wivrn_session(std::unique_ptr<wivrn_connection> connection
 		}
 		catch (...)
 		{
-			U_LOG_W("Could not initialize keyboard & mouse forwarding");
+			U_LOG_W("Could not initialize input forwarding");
 			U_LOG_W("Ensure that the uinput kernel module is loaded and your user is in the input group.");
 			wivrn_ipc_socket_monado->send(from_monado::server_error{
-			        .where = "Could not initialize keyboard & mouse forwarding",
+			        .where = "Could not initialize input forwarding",
 			        .message = "Ensure that the uinput kernel module is loaded and your user is in the input group.",
 			});
 		}
@@ -403,8 +403,9 @@ void wivrn_session::resume_session()
 	if (audio_handle)
 		audio_handle->resume();
 
-	if (uinput_handler)
-		send_control(to_headset::feature_control{to_headset::feature_control::hid_input, true});
+	// Tell the headset whether forwarded input devices are mirrored to uinput. The headset picks
+	// what to forward. The OpenXR gamepad at /user/gamepad is always available regardless.
+	send_control(to_headset::feature_control{to_headset::feature_control::hid_input, bool(uinput_handler)});
 
 	{
 		float target_fps = default_fps();
@@ -480,14 +481,16 @@ void wivrn_session::operator()(from_headset::headset_info_packet &&)
 
 void wivrn_session::operator()(const from_headset::settings_changed & settings)
 {
-	auto locked = this->settings.lock();
-	*locked = settings;
+	*this->settings.lock() = settings;
 
 	if (settings.bitrate_bps != 0)
 		compositor.set_bitrate(settings.bitrate_bps);
 
 	if (settings.preferred_refresh_rate != 0)
 		compositor.set_framerate(settings.preferred_refresh_rate / settings.fps_divider);
+
+	if (not settings.mirror_gamepad and uinput_handler)
+		uinput_handler->destroy_gamepad();
 
 	wivrn_ipc_socket_monado->send(std::move(settings));
 }
@@ -549,7 +552,12 @@ static xrt_device_name get_name(interaction_profile profile)
 void wivrn_session::operator()(const from_headset::tracking & tracking)
 {
 	if (gamepad_device)
-		gamepad_device->set_connected(tracking.interaction_profiles[2] != interaction_profile::none);
+	{
+		gamepad_connected = tracking.interaction_profiles[2] != interaction_profile::none;
+		gamepad_device->set_connected(gamepad_connected);
+		if (not gamepad_connected and uinput_handler)
+			uinput_handler->destroy_gamepad();
+	}
 
 	auto left = (roles.left == -1 || roles.left == left_controller_index || roles.left == left_hand_interaction_index) ? get_name(tracking.interaction_profiles[0]) : XRT_DEVICE_INVALID;
 	auto right = (roles.right == -1 || roles.right == right_controller_index || roles.right == right_hand_interaction_index) ? get_name(tracking.interaction_profiles[1]) : XRT_DEVICE_INVALID;
@@ -683,7 +691,25 @@ void wivrn_session::operator()(from_headset::inputs && inputs)
 		right_controller.set_inputs(inputs, offset);
 
 	if (gamepad_device)
+	{
 		gamepad_device->set_inputs(inputs);
+		try
+		{
+			// Mirror to a uinput gamepad for non-OpenXR consumers, when the
+			// headset opts in and the server permits.
+			if (uinput_handler and gamepad_connected and settings.lock()->mirror_gamepad)
+				uinput_handler->handle_gamepad(inputs);
+		}
+		catch (const std::exception & e)
+		{
+			wivrn_ipc_socket_monado->send(from_monado::server_error{
+			        .where = "Gamepad forwarding error",
+			        .message = e.what(),
+			});
+			U_LOG_E("Gamepad forwarding error: %s", e.what());
+			uinput_handler.reset();
+		}
+	}
 }
 
 void wivrn_session::operator()(from_headset::hid::input && e)
@@ -1005,6 +1031,12 @@ void wivrn_session::run_net(std::stop_token stop)
 		try
 		{
 			connection->poll(*this, 20);
+
+			if (uinput_handler)
+			{
+				for (auto & haptics: uinput_handler->read_rumble())
+					send_stream(std::move(haptics));
+			}
 		}
 		catch (const std::exception & e)
 		{

--- a/server/driver/wivrn_session.cpp
+++ b/server/driver/wivrn_session.cpp
@@ -126,6 +126,11 @@ wivrn::wivrn_session::wivrn_session(std::unique_ptr<wivrn_connection> connection
 	static_roles.hand_tracking.unobstructed.right = static_xdevs[right_controller_index] = &right_controller;
 	static_xdevs[right_hand_interaction_index = static_xdev_count++] = &right_hand_interaction;
 
+	// Expose a gamepad forwarded from the headset as a native OpenXR device (/user/gamepad).
+	// Always present; inactive until the headset reports a connected gamepad.
+	roles.gamepad = static_xdev_count;
+	static_xdevs[static_xdev_count++] = &gamepad_device.emplace(*this);
+
 #if WIVRN_FEATURE_STEAMVR_LIGHTHOUSE
 	auto use_steamvr_lh = configuration().use_steamvr_lh || std::getenv("WIVRN_USE_STEAMVR_LH");
 	xrt_system_devices * lhdevs = NULL;
@@ -543,6 +548,9 @@ static xrt_device_name get_name(interaction_profile profile)
 
 void wivrn_session::operator()(const from_headset::tracking & tracking)
 {
+	if (gamepad_device)
+		gamepad_device->set_connected(tracking.interaction_profiles[2] != interaction_profile::none);
+
 	auto left = (roles.left == -1 || roles.left == left_controller_index || roles.left == left_hand_interaction_index) ? get_name(tracking.interaction_profiles[0]) : XRT_DEVICE_INVALID;
 	auto right = (roles.right == -1 || roles.right == right_controller_index || roles.right == right_hand_interaction_index) ? get_name(tracking.interaction_profiles[1]) : XRT_DEVICE_INVALID;
 	if (left != roles.left_profile or right != roles.right_profile)
@@ -673,6 +681,9 @@ void wivrn_session::operator()(from_headset::inputs && inputs)
 		right_hand_interaction.set_inputs(inputs, offset);
 	else if (roles.right == right_controller_index)
 		right_controller.set_inputs(inputs, offset);
+
+	if (gamepad_device)
+		gamepad_device->set_inputs(inputs);
 }
 
 void wivrn_session::operator()(from_headset::hid::input && e)

--- a/server/driver/wivrn_session.h
+++ b/server/driver/wivrn_session.h
@@ -102,6 +102,7 @@ class wivrn_session : public xrt_system_devices
 	std::optional<wivrn_htc_face_tracker> htc_face_tracker;
 	beman::inplace_vector::inplace_vector<wivrn_generic_tracker, from_headset::body_tracking::max_tracked_poses> generic_trackers;
 	std::optional<wivrn_uinput> uinput_handler;
+	bool gamepad_connected = false; // network thread only
 
 	clock_offset_estimator offset_est;
 	std::atomic<XrDuration> tracking_latency; // production to reception time

--- a/server/driver/wivrn_session.h
+++ b/server/driver/wivrn_session.h
@@ -30,6 +30,7 @@
 #include "wivrn_controller.h"
 #include "wivrn_eye_tracker.h"
 #include "wivrn_fb_face2_tracker.h"
+#include "wivrn_gamepad.h"
 #include "wivrn_generic_tracker.h"
 #include "wivrn_hmd.h"
 #include "wivrn_htc_face_tracker.h"
@@ -95,6 +96,7 @@ class wivrn_session : public xrt_system_devices
 	wivrn_controller right_hand_interaction;
 	int32_t right_hand_interaction_index;
 	std::optional<wivrn_eye_tracker> eye_tracker;
+	std::optional<wivrn_gamepad> gamepad_device;
 	std::optional<wivrn_android_face_tracker> android_face_tracker;
 	std::optional<wivrn_fb_face2_tracker> fb_face2_tracker;
 	std::optional<wivrn_htc_face_tracker> htc_face_tracker;

--- a/server/driver/wivrn_uinput.cpp
+++ b/server/driver/wivrn_uinput.cpp
@@ -1,8 +1,11 @@
 #include "wivrn_uinput.h"
 
 #include "utils/overloaded.h"
+#include "wivrn_gamepad_map.h"
+#include <algorithm>
 #include <array>
 #include <cerrno>
+#include <cmath>
 #include <cstdio>
 #include <cstring>
 
@@ -17,12 +20,12 @@
 
 namespace
 {
-wivrn::fd_base open_uinput_or_throw()
+wivrn::fd_base open_uinput_or_throw(int flags = O_WRONLY)
 {
 	constexpr std::array paths = {"/dev/uinput", "/dev/input/uinput"};
 	for (const char * p: paths)
 	{
-		int fd = ::open(p, O_WRONLY | O_NONBLOCK);
+		int fd = ::open(p, flags | O_NONBLOCK);
 		if (fd >= 0)
 			return fd;
 		if (errno != ENOENT) // exists but inaccessbile
@@ -40,13 +43,18 @@ void write_or_throw(int fd, const void * buf, size_t n)
 		throw std::runtime_error("byte count mismatch while writing to uinput");
 }
 
-void fill_ids(uinput_user_dev & uidev, uint16_t product) noexcept
+void fill_ids(uinput_user_dev & uidev, uint16_t vendor, uint16_t product) noexcept
 {
 	std::memset(&uidev, 0, sizeof(uidev));
 	uidev.id.bustype = 0x03;
-	uidev.id.vendor = 0x4711;
+	uidev.id.vendor = vendor;
 	uidev.id.product = product;
 	uidev.id.version = 5;
+}
+
+void fill_ids(uinput_user_dev & uidev, uint16_t product) noexcept
+{
+	fill_ids(uidev, 0x4711, product);
 }
 
 void emit_ev(int fd, uint16_t type, uint16_t code, int32_t value)
@@ -80,14 +88,14 @@ void ioctl_or_throw(int fd, unsigned long op, unsigned long int arg)
 
 } // namespace
 
-wivrn_uinput::wivrn_uinput()
-{
-	init_keyboard();
-	init_mouse();
-};
-
 void wivrn_uinput::handle_input(wivrn::from_headset::hid::input & e)
 {
+	if (kbd_fd.get_fd() < 0)
+	{
+		init_keyboard();
+		init_mouse();
+	}
+
 	std::visit(utils::overloaded{
 	                   [this](const wivrn::from_headset::hid::key_down & e) {
 		                   send_key(e.key, true);
@@ -109,6 +117,152 @@ void wivrn_uinput::handle_input(wivrn::from_headset::hid::input & e)
 	                   },
 	           },
 	           e.input_data);
+}
+
+namespace
+{
+int16_t scale_stick(float v)
+{
+	v = std::clamp(v, -1.f, 1.f);
+	return (int16_t)std::lround(v * 32767.f);
+}
+
+int16_t scale_trigger(float v)
+{
+	v = std::clamp(v, 0.f, 1.f);
+	return (int16_t)std::lround(v * 255.f);
+}
+} // namespace
+
+void wivrn_uinput::handle_gamepad(const wivrn::from_headset::inputs & inputs)
+{
+	using namespace wivrn;
+	if (gamepad_fd.get_fd() < 0)
+	{
+		// Inputs packets are mostly controller inputs: don't create the device
+		// until the headset actually sends gamepad inputs
+		if (std::ranges::none_of(inputs.values, [](const auto & value) { return map_gamepad(value.id).slot != gp_count; }))
+			return;
+		init_gamepad();
+	}
+	int fd = gamepad_fd.get_fd();
+
+	bool dpad_left = false, dpad_right = false, dpad_up = false, dpad_down = false;
+
+	for (const auto & value: inputs.values)
+	{
+		auto m = map_gamepad(value.id);
+		if (m.slot == gp_count)
+			continue;
+		switch (m.kind)
+		{
+			case gp_value::button:
+				emit_ev(fd, EV_KEY, m.ev_code, value.value != 0);
+				break;
+			case gp_value::trigger:
+				emit_ev(fd, EV_ABS, m.ev_code, scale_trigger(value.value));
+				break;
+			case gp_value::stick_x:
+			case gp_value::stick_y:
+				emit_ev(fd, EV_ABS, m.ev_code, scale_stick(value.value));
+				break;
+			case gp_value::dpad:
+				switch (m.slot)
+				{
+					case gp_dpad_left:
+						dpad_left = value.value != 0;
+						break;
+					case gp_dpad_right:
+						dpad_right = value.value != 0;
+						break;
+					case gp_dpad_up:
+						dpad_up = value.value != 0;
+						break;
+					case gp_dpad_down:
+						dpad_down = value.value != 0;
+						break;
+					default:
+						break;
+				}
+				break;
+		}
+	}
+
+	emit_ev(fd, EV_ABS, ABS_HAT0X, (dpad_right ? 1 : 0) - (dpad_left ? 1 : 0));
+	emit_ev(fd, EV_ABS, ABS_HAT0Y, (dpad_down ? 1 : 0) - (dpad_up ? 1 : 0));
+	syn(fd);
+}
+
+void wivrn_uinput::destroy_gamepad()
+{
+	if (gamepad_fd.get_fd() < 0)
+		return;
+	ioctl(gamepad_fd.get_fd(), UI_DEV_DESTROY);
+	gamepad_fd = {};
+	ff_effects.clear();
+}
+
+std::vector<wivrn::to_headset::haptics> wivrn_uinput::read_rumble()
+{
+	int fd = gamepad_fd.get_fd();
+	if (fd < 0)
+		return {};
+
+	std::vector<wivrn::to_headset::haptics> result;
+	auto motors = [&](float strong, float weak, uint16_t length_ms) {
+		// 0 length is a continuous effect; send a finite burst instead
+		const std::chrono::nanoseconds duration{int64_t(length_ms ? length_ms : 100) * 1'000'000};
+		// strong/weak are motor weights, not locations, so drive both outputs at the combined intensity
+		const float amplitude = std::max(strong, weak);
+		result = {
+		        {wivrn::device_id::GAMEPAD_HAPTIC_LEFT, duration, 0.f, amplitude},
+		        {wivrn::device_id::GAMEPAD_HAPTIC_RIGHT, duration, 0.f, amplitude},
+		};
+	};
+
+	input_event ev;
+	while (::read(fd, &ev, sizeof(ev)) == (ssize_t)sizeof(ev))
+	{
+		if (ev.type == EV_UINPUT and ev.code == UI_FF_UPLOAD)
+		{
+			uinput_ff_upload upload{
+			        .request_id = (uint32_t)ev.value,
+			};
+			if (ioctl(fd, UI_BEGIN_FF_UPLOAD, &upload) == 0)
+			{
+				ff_effects[upload.effect.id] = upload.effect;
+				upload.retval = 0;
+				ioctl(fd, UI_END_FF_UPLOAD, &upload);
+			}
+		}
+		else if (ev.type == EV_UINPUT and ev.code == UI_FF_ERASE)
+		{
+			uinput_ff_erase erase{
+			        .request_id = (uint32_t)ev.value,
+			};
+			if (ioctl(fd, UI_BEGIN_FF_ERASE, &erase) == 0)
+			{
+				ff_effects.erase(erase.effect_id);
+				erase.retval = 0;
+				ioctl(fd, UI_END_FF_ERASE, &erase);
+			}
+		}
+		else if (ev.type == EV_FF)
+		{
+			// ev.code is the effect id, ev.value != 0 starts it, 0 stops it.
+			if (ev.value == 0)
+			{
+				motors(0.f, 0.f, 0);
+			}
+			else if (auto it = ff_effects.find(ev.code); it != ff_effects.end() and it->second.type == FF_RUMBLE)
+			{
+				const auto & rumble = it->second.u.rumble;
+				motors(rumble.strong_magnitude / 65535.f, rumble.weak_magnitude / 65535.f, (uint16_t)it->second.replay.length);
+			}
+		}
+	}
+
+	return result;
 }
 
 void wivrn_uinput::send_key(uint16_t key, bool down)
@@ -184,6 +338,47 @@ void wivrn_uinput::init_mouse()
 	uinput_user_dev uidev;
 	fill_ids(uidev, 0x0839);
 	std::snprintf(uidev.name, sizeof(uidev.name), "WiVRn Mouse");
+	write_or_throw(fd, &uidev, sizeof(uidev));
+	ioctl_or_throw(fd, UI_DEV_CREATE);
+}
+
+void wivrn_uinput::init_gamepad()
+{
+	// O_RDWR to read force-feedback (rumble) back from the device
+	gamepad_fd = open_uinput_or_throw(O_RDWR);
+	int fd = gamepad_fd.get_fd();
+
+	ioctl_or_throw(fd, UI_SET_EVBIT, EV_KEY);
+	ioctl_or_throw(fd, UI_SET_EVBIT, EV_ABS);
+	ioctl_or_throw(fd, UI_SET_EVBIT, EV_FF);
+	ioctl_or_throw(fd, UI_SET_FFBIT, FF_RUMBLE);
+
+	// BTN_GAMEPAD (== BTN_SOUTH) is required or SDL ignores the device
+	for (int code: {BTN_SOUTH, BTN_EAST, BTN_NORTH, BTN_WEST, BTN_TL, BTN_TR, BTN_SELECT, BTN_START, BTN_MODE, BTN_THUMBL, BTN_THUMBR})
+		ioctl_or_throw(fd, UI_SET_KEYBIT, code);
+
+	for (int code: {ABS_X, ABS_Y, ABS_RX, ABS_RY, ABS_Z, ABS_RZ, ABS_HAT0X, ABS_HAT0Y})
+		ioctl_or_throw(fd, UI_SET_ABSBIT, code);
+
+	uinput_user_dev uidev;
+	// Microsoft X-Box vendor/product so Steam Input also recognizes it by GUID
+	fill_ids(uidev, 0x045e, 0x028e);
+	uidev.ff_effects_max = ff_effects_max;
+	std::snprintf(uidev.name, sizeof(uidev.name), "WiVRn Gamepad");
+
+	const auto set_abs = [&](int code, int32_t min, int32_t max, int32_t fuzz, int32_t flat) {
+		uidev.absmin[code] = min;
+		uidev.absmax[code] = max;
+		uidev.absfuzz[code] = fuzz;
+		uidev.absflat[code] = flat;
+	};
+	for (int code: {ABS_X, ABS_Y, ABS_RX, ABS_RY})
+		set_abs(code, -32768, 32767, 16, 128);
+	set_abs(ABS_Z, 0, 255, 0, 0);
+	set_abs(ABS_RZ, 0, 255, 0, 0);
+	set_abs(ABS_HAT0X, -1, 1, 0, 0);
+	set_abs(ABS_HAT0Y, -1, 1, 0, 0);
+
 	write_or_throw(fd, &uidev, sizeof(uidev));
 	ioctl_or_throw(fd, UI_DEV_CREATE);
 }

--- a/server/driver/wivrn_uinput.h
+++ b/server/driver/wivrn_uinput.h
@@ -2,23 +2,42 @@
 #include "wivrn_sockets.h"
 
 #include <cstdint>
+#include <map>
+#include <vector>
+
+#include <linux/uinput.h>
 
 class wivrn_uinput
 {
 public:
-	wivrn_uinput();
+	// Devices are created lazily on first use, so only forwarded classes are exposed.
+	wivrn_uinput() = default;
 
 	void handle_input(wivrn::from_headset::hid::input &);
+
+	// The gamepad device is created on the first packet with gamepad inputs
+	void handle_gamepad(const wivrn::from_headset::inputs &);
+	// Remove the virtual gamepad, when the headset stops mirroring or the gamepad disconnects
+	void destroy_gamepad();
+
+	// Drains pending force-feedback requests from the virtual gamepad and returns the
+	// resulting haptics packets to forward to the headset, if any changed.
+	std::vector<wivrn::to_headset::haptics> read_rumble();
 
 private:
 	void init_keyboard();
 	void init_mouse();
+	void init_gamepad();
 
 	void send_key(uint16_t key, bool down);
 	void send_button(uint16_t mouse_button, bool down);
 	void mouse_move_relative(int16_t x, int16_t y);
 	void mouse_scroll(int16_t vertical, int16_t horizontal);
 
+	static constexpr int ff_effects_max = 16;
+
 	wivrn::fd_base kbd_fd;
 	wivrn::fd_base mouse_fd;
+	wivrn::fd_base gamepad_fd;
+	std::map<int16_t, ff_effect> ff_effects;
 };


### PR DESCRIPTION
## Summary

Adds optional forwarding of a gamepad paired to the headset through to the server. Useful when the controller is in range of the headset but not the server, such as a DualSense paired to a Quest over Bluetooth while streaming to a PC. Off by default.

## Commits

- **Add gamepad forwarding through OpenXR**: the interaction profile data model, no extra config or UI.
- **Mirror forwarded input devices to uinput**: the uinput add-on and its configuration.

## How it works

The headset reads the gamepad through the OpenXR `/interaction_profiles/microsoft/xbox_controller` profile and forwards it on the existing input rails: gamepad `device_id`s in the inputs packet, plus a gamepad entry in the interaction profile array sent from the tracking thread. The switch to `none` signals disconnection.

The server exposes a native OpenXR gamepad xdev at `/user/gamepad`, connected while the headset reports a gamepad interaction profile. This needs no permission and is always available.

It can also mirror the gamepad to a `uinput` device with the standard Xbox layout (`BTN_GAMEPAD` plus a Microsoft VID/PID), so SDL and Steam Input pick it up. The uinput mirror is gated by the `hid-forwarding` server option, which also covers forwarded keyboard and mouse.

Rumble is forwarded back to the headset and applied through OpenXR haptics, best effort.

Only the digested controller state is forwarded, so device specific features such as gyro, adaptive triggers and the touchpad are not available.

## Configuration

The headset chooses which devices to forward (keyboard, mouse, gamepad). The `hid-forwarding` server option gates the uinput mirror only; the OpenXR gamepad is always exposed. With `hid-forwarding` off, the headset reflects that forwarded keyboard and mouse will not reach the server.

The uinput mirror requires the `uinput` kernel module and write access to `/dev/uinput`.

## Testing

Tested on Arch Linux, Quest 3, DualSense over Bluetooth. Buttons, both sticks, analog triggers and d-pad map correctly. Played Project Wingman with no noticeable added latency. Confirmed the same input reaches both the `uinput` device and `/user/gamepad`.
