### PR TITLE
Fix main queue synchronization with monado

### DIFF
--- a/server/compositor/compositor.cpp
+++ b/server/compositor/compositor.cpp
@@ -82,17 +82,6 @@ struct method_trait<Method, Result (wivrn::compositor::*)(Args...)>
 
 namespace
 {
-os_mutex copy_mutex(std::mutex & m)
-{
-	return {
-	        .mutex = *m.native_handle(),
-#ifndef NDEBUG
-	        .initialized = true,
-	        .recursive = false,
-#endif
-	};
-}
-
 const comp_swapchain_image & get_layer_image(const comp_layer & layer, uint32_t swapchain_index, uint32_t image_index)
 {
 	return reinterpret_cast<struct comp_swapchain *>(comp_layer_get_swapchain(&layer, swapchain_index))->images[image_index];
@@ -735,8 +724,11 @@ compositor::compositor(wivrn_session & session) :
 	// vk_init_from_given assumes a graphics queue was provided
 	c_base->vk.graphics_queue = nullptr;
 
+	// Monado submits to the main queue from IPC client threads under
+	// main_queue->mutex: our own submissions must take the same lock.
+	vk::detail::resultCheck(vk::Result(vk_init_mutex(&c_base->vk)), "vk_init_mutex");
 	if (c_base->vk.main_queue)
-		c_base->vk.main_queue->mutex = copy_mutex(vk.queue.mutex);
+		vk.queue.mutex.share(c_base->vk.main_queue->mutex.mutex);
 
 	{
 		comp_vulkan_formats formats{};

--- a/server/utils/wivrn_vk_bundle.h
+++ b/server/utils/wivrn_vk_bundle.h
@@ -23,6 +23,7 @@
 #include <cstdint>
 #include <inplace_vector.hpp>
 #include <mutex>
+#include <pthread.h>
 #include <type_traits>
 #include <vector>
 #include <vulkan/vulkan_raii.hpp>
@@ -62,9 +63,44 @@ uint64_t vk_handle(const T & handle)
 
 struct vk_bundle
 {
+	// Lockable that can be redirected to a pthread_mutex_t owned by monado,
+	// so that all VkQueue submitters take the same lock.
+	class queue_mutex
+	{
+		pthread_mutex_t storage = PTHREAD_MUTEX_INITIALIZER;
+		pthread_mutex_t * mutex = &storage;
+
+	public:
+		queue_mutex() = default;
+		queue_mutex(const queue_mutex &) = delete;
+		queue_mutex & operator=(const queue_mutex &) = delete;
+		~queue_mutex()
+		{
+			pthread_mutex_destroy(&storage);
+		}
+		void lock()
+		{
+			pthread_mutex_lock(mutex);
+		}
+		bool try_lock()
+		{
+			return pthread_mutex_trylock(mutex) == 0;
+		}
+		void unlock()
+		{
+			pthread_mutex_unlock(mutex);
+		}
+		// external must be initialized, not currently locked, and
+		// outlive the last lock()
+		void share(pthread_mutex_t & external)
+		{
+			mutex = &external;
+		}
+	};
+
 	struct queue_data
 	{
-		std::mutex mutex;
+		queue_mutex mutex;
 		vk::raii::Queue queue = nullptr;
 		uint32_t family_index = vk::QueueFamilyIgnored;
 		operator bool() const


### PR DESCRIPTION
Fixes #1021.

`copy_mutex` copied the `pthread_mutex_t` out of `vk.queue.mutex` by value into monado's `main_queue->mutex`, which just makes a second, independent mutex. So monado's submits from IPC client threads (swapchain image transitions, the `vkDeviceWaitIdle` in `image_cleanup`) never actually excluded wivrn's own submissions on the same VkQueue. On NVIDIA this corrupts the driver's queue state whenever a client creates swapchains mid-stream: SIGSEGV inside `vkQueueSubmit2` one day, uncaught `vk::SystemError` from `layer_commit` the next.

Since `os_mutex` embeds its `pthread_mutex_t` by value, monado can't be pointed at our `std::mutex`, so it goes the other way: `vk.queue.mutex` is now a small pthread-based lockable that gets redirected to the main queue's `os_mutex` after `vk_init_mutex`. All call sites unchanged.

Before this I crashed every day or two. Two days clean now on 26.6.1 + NVIDIA 595.84 with wayvr restarting mid-stream, which was the reliable trigger.
