### PR TITLE
Add client-side chroma key passthrough

### DIFF
--- a/client/configuration.cpp
+++ b/client/configuration.cpp
@@ -177,6 +177,33 @@ configuration::configuration(xr::system & system, xr::session & session)
 		if (auto val = root["passthrough_enabled"]; val.is_bool())
 			passthrough_enabled = val.get_bool();
 
+		if (auto ck = root["chroma_key"]; ck.is_object())
+		{
+			if (auto val = ck["enabled"]; val.is_bool())
+				chroma_key.enabled = val.get_bool();
+			auto read_triplet = [](simdjson::simdjson_result<simdjson::dom::element> el, std::array<float, 3> & out) {
+				if (!el.is_array())
+					return;
+				size_t i = 0;
+				for (auto v: simdjson::dom::array(el))
+				{
+					if (i >= out.size())
+						break;
+					if (v.is_double())
+						out[i] = v.get_double();
+					else if (v.is_int64())
+						out[i] = v.get_int64();
+					++i;
+				}
+			};
+			read_triplet(ck["hsv_min"], chroma_key.hsv_min);
+			read_triplet(ck["hsv_max"], chroma_key.hsv_max);
+			if (auto val = ck["curve"]; val.is_double())
+				chroma_key.curve = val.get_double();
+			if (auto val = ck["despill"]; val.is_double())
+				chroma_key.despill = val.get_double();
+		}
+
 		if (auto val = root["mic_unprocessed_audio"]; val.is_bool())
 			mic_unprocessed_audio = val.get_bool();
 
@@ -318,6 +345,13 @@ void configuration::save()
 	json << ",\"openxr_post_processing\":";
 	write_openxr_post_processing(json, openxr_post_processing);
 	json << ",\"passthrough_enabled\":" << std::boolalpha << passthrough_enabled;
+	json << ",\"chroma_key\":{"
+	     << "\"enabled\":" << std::boolalpha << chroma_key.enabled
+	     << ",\"hsv_min\":[" << chroma_key.hsv_min[0] << "," << chroma_key.hsv_min[1] << "," << chroma_key.hsv_min[2] << "]"
+	     << ",\"hsv_max\":[" << chroma_key.hsv_max[0] << "," << chroma_key.hsv_max[1] << "," << chroma_key.hsv_max[2] << "]"
+	     << ",\"curve\":" << chroma_key.curve
+	     << ",\"despill\":" << chroma_key.despill
+	     << "}";
 	json << ",\"mic_unprocessed_audio\":" << std::boolalpha << mic_unprocessed_audio;
 	json << ",\"forward_keyboard\":" << std::boolalpha << forward_keyboard;
 	json << ",\"forward_mouse\":" << std::boolalpha << forward_mouse;

--- a/client/configuration.h
+++ b/client/configuration.h
@@ -22,6 +22,7 @@
 #include "wivrn_discover.h"
 #include "wivrn_packets.h"
 
+#include <array>
 #include <map>
 #include <mutex>
 #include <optional>
@@ -75,6 +76,23 @@ public:
 	bool forward_gamepad = false;
 
 	std::underlying_type_t<wivrn::from_headset::body_part_mask> body_part_mask = ~0;
+
+	// Client-side chroma key passthrough: keys out HSV range from decoded
+	// stream so the headset's passthrough (alpha blend env / FB / HTC) shows
+	// through. Applies to any running application, regardless of whether it
+	// outputs alpha.
+	struct chroma_key_settings
+	{
+		bool enabled = false;
+		// HSV in [0, 1]; hsv_min.h > hsv_max.h wraps around the hue ring.
+		std::array<float, 3> hsv_min{0.25f, 0.30f, 0.15f};
+		std::array<float, 3> hsv_max{0.45f, 1.00f, 1.00f};
+		// Soft falloff width around the HSV range, in normalized HSV units.
+		float curve = 0.10f;
+		// How aggressively to subtract the key hue from surviving pixels.
+		float despill = 0.50f;
+	};
+	chroma_key_settings chroma_key;
 
 	bool enable_stream_gui = true;
 

--- a/client/scenes/stream.cpp
+++ b/client/scenes/stream.cpp
@@ -886,6 +886,8 @@ void scenes::stream::render(const XrFrameState & frame_state)
 	std::array<XrFovf, view_count> fov;
 	std::array<wivrn::to_headset::foveation_parameter, view_count> foveation;
 	bool use_alpha = false;
+	const auto & ck_cfg = application::get_config().chroma_key;
+	const bool chroma_key_active = ck_cfg.enabled && system.passthrough_supported() != xr::passthrough_type::none;
 
 	std::array<stream_defoveator::input, view_count> images;
 	for (size_t i = 0; i < view_count + use_alpha; ++i)
@@ -1030,11 +1032,19 @@ void scenes::stream::render(const XrFrameState & frame_state)
 		const float scale = std::lerp(1, constants::stream::dimming_scale, x);
 		const float bias = std::lerp(0, constants::stream::dimming_bias, x);
 
+		stream_defoveator::chroma_key_params ck_params{
+		        .enabled = chroma_key_active,
+		        .hsv_min = ck_cfg.hsv_min,
+		        .hsv_max = ck_cfg.hsv_max,
+		        .curve = ck_cfg.curve,
+		        .despill = ck_cfg.despill,
+		};
 		defoveator->defoveate(command_buffer,
 		                      foveation,
 		                      images,
 		                      {scale, scale, scale, 1.},
 		                      {bias, bias, bias, 0.},
+		                      ck_params,
 		                      image_index);
 
 		command_buffer.writeTimestamp(vk::PipelineStageFlagBits::eBottomOfPipe, *query_pool, 1);
@@ -1071,12 +1081,13 @@ void scenes::stream::render(const XrFrameState & frame_state)
 #endif
 		swapchain.release();
 
-		if (use_alpha)
+		const bool want_passthrough = use_alpha || chroma_key_active;
+		if (want_passthrough)
 			session.enable_passthrough(system);
 		else
 			session.disable_passthrough();
 
-		render_start(use_alpha, frame_state.predictedDisplayTime);
+		render_start(want_passthrough, frame_state.predictedDisplayTime);
 
 		// Add the layer with the streamed content
 		std::array<XrCompositionLayerProjectionView, view_count> layer_view;
@@ -1099,7 +1110,7 @@ void scenes::stream::render(const XrFrameState & frame_state)
 			        };
 		}
 		add_projection_layer(
-		        use_alpha ? XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT : 0,
+		        want_passthrough ? XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT : 0,
 		        application::space(xr::spaces::world),
 		        layer_view);
 

--- a/client/scenes/stream_defoveator.cpp
+++ b/client/scenes/stream_defoveator.cpp
@@ -45,6 +45,11 @@ struct vert_pc
 	glm::ivec4 a_rect;
 	std::array<float, 4> scale;
 	std::array<float, 4> bias;
+	// Chroma key (see reprojection.glsl). Packed layout: params.x = enabled
+	// (0/1 as float), y = curve, z = despill, w reserved.
+	std::array<float, 4> chroma_key_params;
+	std::array<float, 4> chroma_key_hsv_min; // xyz used, w padding
+	std::array<float, 4> chroma_key_hsv_max;
 };
 
 void stream_defoveator::ensure_vertices(size_t num_vertices)
@@ -308,6 +313,7 @@ void stream_defoveator::defoveate(vk::raii::CommandBuffer & command_buffer,
                                   const std::array<input, 2> & inputs,
                                   std::array<float, 4> scale,
                                   std::array<float, 4> bias,
+                                  const chroma_key_params & chroma_key,
                                   int destination)
 {
 	if (destination < 0 || destination >= (int)output_images.size())
@@ -430,6 +436,9 @@ void stream_defoveator::defoveate(vk::raii::CommandBuffer & command_buffer,
 		                             input.rect_a.extent.height),
 		        .scale = scale,
 		        .bias = bias,
+		        .chroma_key_params = {chroma_key.enabled ? 1.f : 0.f, chroma_key.curve, chroma_key.despill, 0.f},
+		        .chroma_key_hsv_min = {chroma_key.hsv_min[0], chroma_key.hsv_min[1], chroma_key.hsv_min[2], 0.f},
+		        .chroma_key_hsv_max = {chroma_key.hsv_max[0], chroma_key.hsv_max[1], chroma_key.hsv_max[2], 0.f},
 		};
 
 		device.updateDescriptorSets(descriptor_writes, {});

--- a/client/scenes/stream_defoveator.h
+++ b/client/scenes/stream_defoveator.h
@@ -21,11 +21,25 @@
 
 #include "vk/allocation.h"
 #include "wivrn_packets.h"
+#include <array>
 #include <vulkan/vulkan_raii.hpp>
 #include <openxr/openxr.h>
 
 class stream_defoveator
 {
+public:
+	// Parameters for the client-side chroma key. Mirrors configuration::chroma_key_settings
+	// but lives here so the defoveator stays decoupled from configuration.
+	struct chroma_key_params
+	{
+		bool enabled = false;
+		std::array<float, 3> hsv_min{0.f, 0.f, 0.f};
+		std::array<float, 3> hsv_max{1.f, 1.f, 1.f};
+		float curve = 0.f;
+		float despill = 0.f;
+	};
+
+private:
 	struct vertex;
 	static const uint32_t view_count = 2;
 	// Vertex buffer
@@ -89,6 +103,7 @@ public:
 	        const std::array<input, 2> & inputs,
 	        std::array<float, 4> scale,
 	        std::array<float, 4> bias,
+	        const chroma_key_params & chroma_key,
 	        int destination);
 
 	static XrExtent2Di defoveated_size(const wivrn::to_headset::foveation_parameter &);

--- a/client/scenes/stream_gui.cpp
+++ b/client/scenes/stream_gui.cpp
@@ -526,6 +526,51 @@ void scenes::stream::gui_settings(float predicted_display_period)
 		if (ImGui::IsItemHovered())
 			imgui_ctx->tooltip(_("Reduce the key color tinting remaining pixels (useful for green screens)."));
 
+		// Preview: hue bar with the keyed range shown saturated, the rest dimmed,
+		// plus a swatch of the centre of the selected HSV range.
+		{
+			ImGui::Text("%s", _S("Key color preview"));
+			const float h_min = ck.hsv_min[0];
+			const float h_max = ck.hsv_max[0];
+			const bool wrap = h_min > h_max;
+
+			float h_center = wrap
+			                         ? std::fmod(h_min + std::fmod(h_max - h_min + 1.f, 1.f) * 0.5f, 1.f)
+			                         : 0.5f * (h_min + h_max);
+			float r, g, b;
+			ImGui::ColorConvertHSVtoRGB(h_center,
+			                            0.5f * (ck.hsv_min[1] + ck.hsv_max[1]),
+			                            0.5f * (ck.hsv_min[2] + ck.hsv_max[2]),
+			                            r,
+			                            g,
+			                            b);
+			const float height = ImGui::GetFrameHeight();
+			ImGui::ColorButton("##chroma_key_center", ImVec4(r, g, b, 1), ImGuiColorEditFlags_NoTooltip | ImGuiColorEditFlags_NoDragDrop, ImVec2(height * 2, height));
+			ImGui::SameLine();
+
+			ImDrawList * draw_list = ImGui::GetWindowDrawList();
+			const ImVec2 pos = ImGui::GetCursorScreenPos();
+			const float width = ImGui::GetContentRegionAvail().x;
+			const int segments = 64;
+			for (int i = 0; i < segments; ++i)
+			{
+				const float h0 = float(i) / segments;
+				const float h1 = float(i + 1) / segments;
+				const float h = 0.5f * (h0 + h1);
+				const bool inside = wrap ? (h >= h_min or h <= h_max) : (h >= h_min and h <= h_max);
+				ImGui::ColorConvertHSVtoRGB(h,
+				                            inside ? ck.hsv_max[1] : 0.25f,
+				                            inside ? ck.hsv_max[2] : 0.35f,
+				                            r,
+				                            g,
+				                            b);
+				draw_list->AddRectFilled(ImVec2(pos.x + width * h0, pos.y),
+				                         ImVec2(pos.x + width * h1, pos.y + height),
+				                         ImGui::ColorConvertFloat4ToU32(ImVec4(r, g, b, 1)));
+			}
+			ImGui::Dummy(ImVec2(width, height));
+		}
+
 		if (ImGui::Button(_S("Reset chroma key")))
 		{
 			ck = configuration::chroma_key_settings{};

--- a/client/scenes/stream_gui.cpp
+++ b/client/scenes/stream_gui.cpp
@@ -475,6 +475,74 @@ void scenes::stream::gui_settings(float predicted_display_period)
 		config.override_foveation_distance = override_foveation_distance;
 		config.save();
 	}
+
+	// Chroma key passthrough (ALVR-style, client-side).
+	ImGui::Text("%s", _S("Chroma key passthrough"));
+	ImGui::Indent();
+	{
+		auto & ck = config.chroma_key;
+		const bool passthrough_supported = system.passthrough_supported() != xr::passthrough_type::none;
+		ImGui::BeginDisabled(!passthrough_supported);
+		bool ck_dirty = false;
+		if (ImGui::Checkbox(_S("Enable chroma key"), &ck.enabled))
+			ck_dirty = true;
+		imgui_ctx->vibrate_on_hover();
+		if (ImGui::IsItemHovered())
+			imgui_ctx->tooltip(_("Replace pixels inside the HSV range below with the passthrough view.\nApplies to any running application, even when it does not output alpha."));
+
+		ImGui::BeginDisabled(!ck.enabled);
+		if (ImGui::SliderFloat(_S("Hue min"), &ck.hsv_min[0], 0.f, 1.f, "%.3f"))
+			ck_dirty = true;
+		imgui_ctx->vibrate_on_hover();
+		if (ImGui::SliderFloat(_S("Hue max"), &ck.hsv_max[0], 0.f, 1.f, "%.3f"))
+			ck_dirty = true;
+		imgui_ctx->vibrate_on_hover();
+		if (ImGui::IsItemHovered())
+			imgui_ctx->tooltip(_("Hue range. If min > max the range wraps around 0/1 (useful for reds)."));
+
+		if (ImGui::SliderFloat(_S("Saturation min"), &ck.hsv_min[1], 0.f, 1.f, "%.3f"))
+			ck_dirty = true;
+		imgui_ctx->vibrate_on_hover();
+		if (ImGui::SliderFloat(_S("Saturation max"), &ck.hsv_max[1], 0.f, 1.f, "%.3f"))
+			ck_dirty = true;
+		imgui_ctx->vibrate_on_hover();
+
+		if (ImGui::SliderFloat(_S("Value min"), &ck.hsv_min[2], 0.f, 1.f, "%.3f"))
+			ck_dirty = true;
+		imgui_ctx->vibrate_on_hover();
+		if (ImGui::SliderFloat(_S("Value max"), &ck.hsv_max[2], 0.f, 1.f, "%.3f"))
+			ck_dirty = true;
+		imgui_ctx->vibrate_on_hover();
+
+		if (ImGui::SliderFloat(_S("Softness"), &ck.curve, 0.f, 0.5f, "%.3f"))
+			ck_dirty = true;
+		imgui_ctx->vibrate_on_hover();
+		if (ImGui::IsItemHovered())
+			imgui_ctx->tooltip(_("Feathering width around the HSV range. Larger values blend the edges more smoothly."));
+
+		if (ImGui::SliderFloat(_S("Despill"), &ck.despill, 0.f, 1.f, "%.2f"))
+			ck_dirty = true;
+		imgui_ctx->vibrate_on_hover();
+		if (ImGui::IsItemHovered())
+			imgui_ctx->tooltip(_("Reduce the key color tinting remaining pixels (useful for green screens)."));
+
+		if (ImGui::Button(_S("Reset chroma key")))
+		{
+			ck = configuration::chroma_key_settings{};
+			ck_dirty = true;
+		}
+		imgui_ctx->vibrate_on_hover();
+		ImGui::EndDisabled();
+
+		if (ck_dirty)
+			config.save();
+		ImGui::EndDisabled();
+
+		if (!passthrough_supported)
+			ImGui::TextDisabled("%s", _S("Passthrough not supported on this headset"));
+	}
+	ImGui::Unindent();
+
 	ImGui::PopStyleVar();
 }
 

--- a/client/shaders/reprojection.glsl
+++ b/client/shaders/reprojection.glsl
@@ -24,7 +24,17 @@ layout(push_constant) uniform pc
 	ivec4 a_rect;
 	vec4 scale;
 	vec4 bias;
+	// Client-side chroma key passthrough. Packed into 3 vec4s to stay well
+	// under the 128-byte Vulkan push constant minimum.
+	//   x = enabled (0/1), y = curve, z = despill, w = reserved.
+	vec4 chroma_key_params;
+	vec4 chroma_key_hsv_min; // xyz = HSV min, w unused
+	vec4 chroma_key_hsv_max; // xyz = HSV max, w unused
 };
+
+#define chroma_key_enabled (chroma_key_params.x > 0.5)
+#define chroma_key_curve   chroma_key_params.y
+#define chroma_key_despill chroma_key_params.z
 
 #ifdef VERT_SHADER
 
@@ -69,6 +79,72 @@ vec4 sRGB_to_linear_rgba(vec4 x)
 	        x.a);
 }
 
+// Standard RGB -> HSV conversion (Sam Hocevar's trick).
+vec3 rgb_to_hsv(vec3 c)
+{
+	vec4 K = vec4(0.0, -1.0/3.0, 2.0/3.0, -1.0);
+	vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));
+	vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));
+	float d = q.x - min(q.w, q.y);
+	float e = 1.0e-10;
+	return vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)),
+	            d / (q.x + e),
+	            q.x);
+}
+
+// Hue is circular: if min.h > max.h the range wraps around 0/1.
+float hue_in_range(float h, float hmin, float hmax, float soft)
+{
+	if (hmin <= hmax)
+	{
+		float lo = smoothstep(hmin - soft, hmin, h);
+		float hi = 1.0 - smoothstep(hmax, hmax + soft, h);
+		return lo * hi;
+	}
+	else
+	{
+		float lo = smoothstep(hmin - soft, hmin, h);
+		float hi = 1.0 - smoothstep(hmax, hmax + soft, h);
+		return max(lo, hi);
+	}
+}
+
+// Returns 1.0 when the pixel should be kept, 0.0 when it should be keyed out.
+float chroma_key_mask(vec3 rgb_sample)
+{
+	vec3 hsv = rgb_to_hsv(rgb_sample);
+	float soft = max(chroma_key_curve, 1.0e-4);
+	float h = hue_in_range(hsv.x, chroma_key_hsv_min.x, chroma_key_hsv_max.x, soft);
+	float s = smoothstep(chroma_key_hsv_min.y - soft, chroma_key_hsv_min.y, hsv.y)
+	        * (1.0 - smoothstep(chroma_key_hsv_max.y, chroma_key_hsv_max.y + soft, hsv.y));
+	float v = smoothstep(chroma_key_hsv_min.z - soft, chroma_key_hsv_min.z, hsv.z)
+	        * (1.0 - smoothstep(chroma_key_hsv_max.z, chroma_key_hsv_max.z + soft, hsv.z));
+	// All three must be inside the range (product) to count as keyed.
+	float inside = h * s * v;
+	return 1.0 - inside;
+}
+
+// Reduce residual spill of the key color (typically green) on kept pixels.
+vec3 despill(vec3 c)
+{
+	if (chroma_key_despill <= 0.0)
+		return c;
+	// Use the midpoint of the HSV hue range as the key hue.
+	float hmin = chroma_key_hsv_min.x;
+	float hmax = chroma_key_hsv_max.x;
+	float hkey = (hmax >= hmin) ? 0.5 * (hmin + hmax) : fract(0.5 * (hmin + hmax + 1.0));
+	// Map hue in [0, 1] to a color channel emphasis: green around 1/3, red 0, blue 2/3.
+	// Simple subtractive desaturation: clamp the key channel to the average of the others.
+	vec3 limit;
+	if (hkey < 1.0/6.0 || hkey >= 5.0/6.0)
+		limit = vec3(0.5 * (c.g + c.b), c.g, c.b); // red key
+	else if (hkey < 0.5)
+		limit = vec3(c.r, 0.5 * (c.r + c.b), c.b); // green key
+	else
+		limit = vec3(c.r, c.g, 0.5 * (c.r + c.g)); // blue key
+	return mix(c, min(c, limit), clamp(chroma_key_despill, 0.0, 1.0));
+}
+
 void main()
 {
 	if (alpha == 1)
@@ -88,7 +164,18 @@ void main()
 		outColor = sRGB_to_linear_rgba(outColor);
 	}
 
-	if (alpha == 0)
+	// Apply chroma key only when the stream has no real alpha channel.
+	// When the app itself provides alpha (alpha == 1) we trust it and avoid
+	// double-masking.
+	bool ck_active = (alpha == 0) && chroma_key_enabled;
+	if (ck_active)
+	{
+		float m = chroma_key_mask(outColor.rgb);
+		outColor.rgb = despill(outColor.rgb);
+		outColor.a = m;
+	}
+
+	if (alpha == 0 && !ck_active)
 	{
 		outColor = outColor * scale + bias;
 	}


### PR DESCRIPTION
Implements client-side chroma keying for the entire decoded video stream, similar to the workflow supported by Virtual Desktop and ALVR.

This allows the headset’s passthrough environment—FB, HTC, or another alpha-blend environment—to be used with OpenXR applications that do not output alpha themselves.

Because the keying is applied to the final decoded stream on the WiVRn client, it can also be used with compositor overlays included in that stream. For example, an overlay application can display a chroma-key-coloured region to create an arbitrarily positioned passthrough window, without requiring support from the underlying application, VRChat avatar, or world.

This differs from WayVR’s existing chroma key feature, which applies to content presented through WayVR and does not provide the same whole-stream workflow.

## Motivation

Some applications do not provide alpha output, and modifying the application itself is not always practical or possible.

Applying chroma keying at the WiVRn client level makes the feature application-independent and enables workflows such as:

* Creating passthrough regions from an overlay application
* Using passthrough in applications that do not support alpha composition
* Avoiding application-, avatar-, or world-specific chroma key implementations
* Reproducing Virtual Desktop-style passthrough workflows on Linux

## Implementation

* The decoded video is sampled in the reprojection fragment shader.
* Pixels inside a configurable HSV range are made transparent.
* A configurable soft falloff, controlled by `curve`, is applied around the selected range.
* A despill pass attenuates residual key colour on pixels that remain visible.
* When chroma keying is enabled, stream composition is routed through the existing alpha-blend path, enabling passthrough automatically.
* Configuration is stored in `client/configuration.{h,cpp}` and persisted through JSON.
* The following settings are exposed in the in-headset stream settings GUI:

  * `enabled`
  * `hsv_min`
  * `hsv_max`
  * `curve`
  * `despill`
* The GUI includes:

  * Sliders for all configurable parameters
  * A hue-bar preview showing the selected key range
  * Support for hue-range wrap-around
  * A colour swatch representing the centre of the selected range
* Parameters are passed to the shader through a packed push-constant block in the defoveator.
* The existing “stream provides its own alpha” path is preserved.
* Native stream alpha and chroma keying are mutually exclusive to prevent double masking.

## Compatibility

* Client-side only
* No protocol changes
* No server-side support required
* Applications do not need to output alpha or implement chroma keying themselves

## Testing

Verified on-device with a headset supporting an alpha-blend passthrough environment.

Confirmed that:

* Keyed regions reveal the real-world passthrough view
* Chroma keying works with content included in the decoded stream
* Despill reduces green fringing around surviving pixels
* Hue-range wrap-around behaves correctly
* Settings persist across client restarts
* The existing native-alpha stream path continues to work when chroma keying is disabled

## Additional build fix

Also includes a small unrelated build fix:

* Adds the missing `<unistd.h>` include to `server/encoder/ffmpeg/video_encoder_va.cpp`
* Fixes `dup` and `close` being undeclared with recent toolchains

https://github.com/user-attachments/assets/a8dd02ea-95fd-4367-9dca-135fd1a89757
