### PR TITLE
Add sunglasses mode: dim the stream with a configurable colour tint

### DIFF
--- a/client/application.cpp
+++ b/client/application.cpp
@@ -43,6 +43,7 @@
 #include <ctype.h>
 #include <exception>
 #include <magic_enum.hpp>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <vector>

--- a/client/configuration.cpp
+++ b/client/configuration.cpp
@@ -25,6 +25,7 @@
 
 #include <fstream>
 #include <magic_enum.hpp>
+#include <mutex>
 
 #ifdef __ANDROID__
 #include "android/permissions.h"
@@ -204,6 +205,30 @@ configuration::configuration(xr::system & system, xr::session & session)
 				chroma_key.despill = val.get_double();
 		}
 
+		if (auto sg = root["sunglasses"]; sg.is_object())
+		{
+			if (auto val = sg["enabled"]; val.is_bool())
+				sunglasses.enabled = val.get_bool();
+			auto read_triplet = [](simdjson::simdjson_result<simdjson::dom::element> el, std::array<float, 3> & out) {
+				if (!el.is_array())
+					return;
+				size_t i = 0;
+				for (auto v: simdjson::dom::array(el))
+				{
+					if (i >= out.size())
+						break;
+					if (v.is_double())
+						out[i] = v.get_double();
+					else if (v.is_int64())
+						out[i] = v.get_int64();
+					++i;
+				}
+			};
+			read_triplet(sg["hsv"], sunglasses.hsv);
+			if (auto val = sg["alpha"]; val.is_double())
+				sunglasses.alpha = val.get_double();
+		}
+
 		if (auto val = root["mic_unprocessed_audio"]; val.is_bool())
 			mic_unprocessed_audio = val.get_bool();
 
@@ -351,6 +376,11 @@ void configuration::save()
 	     << ",\"hsv_max\":[" << chroma_key.hsv_max[0] << "," << chroma_key.hsv_max[1] << "," << chroma_key.hsv_max[2] << "]"
 	     << ",\"curve\":" << chroma_key.curve
 	     << ",\"despill\":" << chroma_key.despill
+	     << "}";
+	json << ",\"sunglasses\":{"
+	     << "\"enabled\":" << std::boolalpha << sunglasses.enabled
+	     << ",\"hsv\":[" << sunglasses.hsv[0] << "," << sunglasses.hsv[1] << "," << sunglasses.hsv[2] << "]"
+	     << ",\"alpha\":" << sunglasses.alpha
 	     << "}";
 	json << ",\"mic_unprocessed_audio\":" << std::boolalpha << mic_unprocessed_audio;
 	json << ",\"forward_keyboard\":" << std::boolalpha << forward_keyboard;

--- a/client/configuration.cpp
+++ b/client/configuration.cpp
@@ -177,6 +177,33 @@ configuration::configuration(xr::system & system, xr::session & session)
 		if (auto val = root["passthrough_enabled"]; val.is_bool())
 			passthrough_enabled = val.get_bool();
 
+		if (auto ck = root["chroma_key"]; ck.is_object())
+		{
+			if (auto val = ck["enabled"]; val.is_bool())
+				chroma_key.enabled = val.get_bool();
+			auto read_triplet = [](simdjson::simdjson_result<simdjson::dom::element> el, std::array<float, 3> & out) {
+				if (!el.is_array())
+					return;
+				size_t i = 0;
+				for (auto v: simdjson::dom::array(el))
+				{
+					if (i >= out.size())
+						break;
+					if (v.is_double())
+						out[i] = v.get_double();
+					else if (v.is_int64())
+						out[i] = v.get_int64();
+					++i;
+				}
+			};
+			read_triplet(ck["hsv_min"], chroma_key.hsv_min);
+			read_triplet(ck["hsv_max"], chroma_key.hsv_max);
+			if (auto val = ck["curve"]; val.is_double())
+				chroma_key.curve = val.get_double();
+			if (auto val = ck["despill"]; val.is_double())
+				chroma_key.despill = val.get_double();
+		}
+
 		if (auto val = root["mic_unprocessed_audio"]; val.is_bool())
 			mic_unprocessed_audio = val.get_bool();
 
@@ -318,6 +345,13 @@ void configuration::save()
 	json << ",\"openxr_post_processing\":";
 	write_openxr_post_processing(json, openxr_post_processing);
 	json << ",\"passthrough_enabled\":" << std::boolalpha << passthrough_enabled;
+	json << ",\"chroma_key\":{"
+	     << "\"enabled\":" << std::boolalpha << chroma_key.enabled
+	     << ",\"hsv_min\":[" << chroma_key.hsv_min[0] << "," << chroma_key.hsv_min[1] << "," << chroma_key.hsv_min[2] << "]"
+	     << ",\"hsv_max\":[" << chroma_key.hsv_max[0] << "," << chroma_key.hsv_max[1] << "," << chroma_key.hsv_max[2] << "]"
+	     << ",\"curve\":" << chroma_key.curve
+	     << ",\"despill\":" << chroma_key.despill
+	     << "}";
 	json << ",\"mic_unprocessed_audio\":" << std::boolalpha << mic_unprocessed_audio;
 	json << ",\"forward_keyboard\":" << std::boolalpha << forward_keyboard;
 	json << ",\"forward_mouse\":" << std::boolalpha << forward_mouse;

--- a/client/configuration.h
+++ b/client/configuration.h
@@ -22,6 +22,7 @@
 #include "wivrn_discover.h"
 #include "wivrn_packets.h"
 
+#include <array>
 #include <map>
 #include <mutex>
 #include <optional>
@@ -75,6 +76,23 @@ public:
 	bool forward_gamepad = false;
 
 	std::underlying_type_t<wivrn::from_headset::body_part_mask> body_part_mask = ~0;
+
+	// Client-side chroma key passthrough: keys out HSV range from decoded
+	// stream so the headset's passthrough (alpha blend env / FB / HTC) shows
+	// through. Applies to any running application, regardless of whether it
+	// outputs alpha.
+	struct chroma_key_settings
+	{
+		bool enabled = false;
+		// HSV in [0, 1]; hsv_min.h > hsv_max.h wraps around the hue ring.
+		std::array<float, 3> hsv_min{0.25f, 0.30f, 0.15f};
+		std::array<float, 3> hsv_max{0.45f, 1.00f, 1.00f};
+		// Soft falloff width around the HSV range, in normalized HSV units.
+		float curve = 0.10f;
+		// How aggressively to subtract the key hue from surviving pixels.
+		float despill = 0.50f;
+	};
+	chroma_key_settings chroma_key;
 
 	bool enable_stream_gui = true;
 

--- a/client/configuration.h
+++ b/client/configuration.h
@@ -94,6 +94,19 @@ public:
 	};
 	chroma_key_settings chroma_key;
 
+	// Sunglasses: blends a solid colour over the decoded stream to dim it.
+	// Only affects the stream layer, passthrough regions keep their real
+	// brightness.
+	struct sunglasses_settings
+	{
+		bool enabled = false;
+		// HSV in [0, 1]; default black = pure dimming.
+		std::array<float, 3> hsv{0.f, 0.f, 0.f};
+		// Blend strength: 0 = invisible, 1 = fully opaque tint.
+		float alpha = 0.3f;
+	};
+	sunglasses_settings sunglasses;
+
 	bool enable_stream_gui = true;
 
 	// XR_FB_composition_layer_settings extension flags

--- a/client/decoder/ffmpeg/ffmpeg_decoder.cpp
+++ b/client/decoder/ffmpeg/ffmpeg_decoder.cpp
@@ -22,6 +22,7 @@
 #include "scenes/stream.h"
 #include "spdlog/spdlog.h"
 #include <cassert>
+#include <mutex>
 #include <vulkan/vulkan.hpp>
 
 extern "C"

--- a/client/scenes/stream.cpp
+++ b/client/scenes/stream.cpp
@@ -53,6 +53,16 @@
 using namespace wivrn;
 using namespace beman::inplace_vector;
 
+static std::array<float, 3> hsv_to_rgb(const std::array<float, 3> & hsv)
+{
+	const float h = hsv[0] * 6, s = hsv[1], v = hsv[2];
+	auto f = [&](float n) {
+		float k = std::fmod(n + h, 6.f);
+		return v - v * s * std::clamp(std::min(k, 4 - k), 0.f, 1.f);
+	};
+	return {f(5), f(3), f(1)};
+}
+
 // clang-format off
 static const std::unordered_map<std::string, device_id> device_ids = {
 	{"/user/hand/left/input/x/click",             device_id::X_CLICK},
@@ -1039,12 +1049,19 @@ void scenes::stream::render(const XrFrameState & frame_state)
 		        .curve = ck_cfg.curve,
 		        .despill = ck_cfg.despill,
 		};
+		const auto & sg_cfg = application::get_config().sunglasses;
+		stream_defoveator::sunglasses_params sg_params{
+		        .enabled = sg_cfg.enabled,
+		        .rgb = hsv_to_rgb(sg_cfg.hsv),
+		        .alpha = sg_cfg.alpha,
+		};
 		defoveator->defoveate(command_buffer,
 		                      foveation,
 		                      images,
 		                      {scale, scale, scale, 1.},
 		                      {bias, bias, bias, 0.},
 		                      ck_params,
+		                      sg_params,
 		                      image_index);
 
 		command_buffer.writeTimestamp(vk::PipelineStageFlagBits::eBottomOfPipe, *query_pool, 1);

--- a/client/scenes/stream.cpp
+++ b/client/scenes/stream.cpp
@@ -886,6 +886,8 @@ void scenes::stream::render(const XrFrameState & frame_state)
 	std::array<XrFovf, view_count> fov;
 	std::array<wivrn::to_headset::foveation_parameter, view_count> foveation;
 	bool use_alpha = false;
+	const auto & ck_cfg = application::get_config().chroma_key;
+	const bool chroma_key_active = ck_cfg.enabled && system.passthrough_supported() != xr::passthrough_type::none;
 
 	std::array<stream_defoveator::input, view_count> images;
 	for (size_t i = 0; i < view_count + use_alpha; ++i)
@@ -1030,11 +1032,19 @@ void scenes::stream::render(const XrFrameState & frame_state)
 		const float scale = std::lerp(1, constants::stream::dimming_scale, x);
 		const float bias = std::lerp(0, constants::stream::dimming_bias, x);
 
+		stream_defoveator::chroma_key_params ck_params{
+		        .enabled = chroma_key_active,
+		        .hsv_min = ck_cfg.hsv_min,
+		        .hsv_max = ck_cfg.hsv_max,
+		        .curve = ck_cfg.curve,
+		        .despill = ck_cfg.despill,
+		};
 		defoveator->defoveate(command_buffer,
 		                      foveation,
 		                      images,
 		                      {scale, scale, scale, 1.},
 		                      {bias, bias, bias, 0.},
+		                      ck_params,
 		                      image_index);
 
 		command_buffer.writeTimestamp(vk::PipelineStageFlagBits::eBottomOfPipe, *query_pool, 1);
@@ -1071,12 +1081,13 @@ void scenes::stream::render(const XrFrameState & frame_state)
 #endif
 		swapchain.release();
 
-		if (use_alpha)
+		const bool want_passthrough = use_alpha || chroma_key_active;
+		if (want_passthrough)
 			session.enable_passthrough(system);
 		else
 			session.disable_passthrough();
 
-		render_start(use_alpha, frame_state.predictedDisplayTime);
+		render_start(want_passthrough, frame_state.predictedDisplayTime);
 
 		// Add the layer with the streamed content
 		std::array<XrCompositionLayerProjectionView, view_count> layer_view;
@@ -1099,7 +1110,7 @@ void scenes::stream::render(const XrFrameState & frame_state)
 			        };
 		}
 		add_projection_layer(
-		        use_alpha ? XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT : 0,
+		        want_passthrough ? XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT : 0,
 		        application::space(xr::spaces::world),
 		        layer_view);
 

--- a/client/scenes/stream_defoveator.cpp
+++ b/client/scenes/stream_defoveator.cpp
@@ -45,6 +45,11 @@ struct vert_pc
 	glm::ivec4 a_rect;
 	std::array<float, 4> scale;
 	std::array<float, 4> bias;
+	// Chroma key (see reprojection.glsl). Packed layout: params.x = enabled
+	// (0/1 as float), y = curve, z = despill, w reserved.
+	std::array<float, 4> chroma_key_params;
+	std::array<float, 4> chroma_key_hsv_min; // xyz used, w padding
+	std::array<float, 4> chroma_key_hsv_max;
 };
 
 void stream_defoveator::ensure_vertices(size_t num_vertices)
@@ -308,6 +313,7 @@ void stream_defoveator::defoveate(vk::raii::CommandBuffer & command_buffer,
                                   const std::array<input, 2> & inputs,
                                   std::array<float, 4> scale,
                                   std::array<float, 4> bias,
+                                  const chroma_key_params & chroma_key,
                                   int destination)
 {
 	if (destination < 0 || destination >= (int)output_images.size())
@@ -430,6 +436,9 @@ void stream_defoveator::defoveate(vk::raii::CommandBuffer & command_buffer,
 		                             input.rect_a.extent.height),
 		        .scale = scale,
 		        .bias = bias,
+		        .chroma_key_params = {chroma_key.enabled ? 1.f : 0.f, chroma_key.curve, chroma_key.despill, 0.f},
+		        .chroma_key_hsv_min = {chroma_key.hsv_min[0], chroma_key.hsv_min[1], chroma_key.hsv_min[2], 0.f},
+		        .chroma_key_hsv_max = {chroma_key.hsv_max[0], chroma_key.hsv_max[1], chroma_key.hsv_max[2], 0.f},
 		};
 
 		device.updateDescriptorSets(descriptor_writes, {});

--- a/client/scenes/stream_defoveator.cpp
+++ b/client/scenes/stream_defoveator.cpp
@@ -50,6 +50,8 @@ struct vert_pc
 	std::array<float, 4> chroma_key_params;
 	std::array<float, 4> chroma_key_hsv_min; // xyz used, w padding
 	std::array<float, 4> chroma_key_hsv_max;
+	// Sunglasses tint: xyz = linear RGB, w = blend strength (0 when disabled).
+	std::array<float, 4> sunglasses_tint;
 };
 
 void stream_defoveator::ensure_vertices(size_t num_vertices)
@@ -314,6 +316,7 @@ void stream_defoveator::defoveate(vk::raii::CommandBuffer & command_buffer,
                                   std::array<float, 4> scale,
                                   std::array<float, 4> bias,
                                   const chroma_key_params & chroma_key,
+                                  const sunglasses_params & sunglasses,
                                   int destination)
 {
 	if (destination < 0 || destination >= (int)output_images.size())
@@ -439,6 +442,7 @@ void stream_defoveator::defoveate(vk::raii::CommandBuffer & command_buffer,
 		        .chroma_key_params = {chroma_key.enabled ? 1.f : 0.f, chroma_key.curve, chroma_key.despill, 0.f},
 		        .chroma_key_hsv_min = {chroma_key.hsv_min[0], chroma_key.hsv_min[1], chroma_key.hsv_min[2], 0.f},
 		        .chroma_key_hsv_max = {chroma_key.hsv_max[0], chroma_key.hsv_max[1], chroma_key.hsv_max[2], 0.f},
+		        .sunglasses_tint = {sunglasses.rgb[0], sunglasses.rgb[1], sunglasses.rgb[2], sunglasses.enabled ? sunglasses.alpha : 0.f},
 		};
 
 		device.updateDescriptorSets(descriptor_writes, {});

--- a/client/scenes/stream_defoveator.h
+++ b/client/scenes/stream_defoveator.h
@@ -21,11 +21,25 @@
 
 #include "vk/allocation.h"
 #include "wivrn_packets.h"
+#include <array>
 #include <vulkan/vulkan_raii.hpp>
 #include <openxr/openxr.h>
 
 class stream_defoveator
 {
+public:
+	// Parameters for the client-side chroma key. Mirrors configuration::chroma_key_settings
+	// but lives here so the defoveator stays decoupled from configuration.
+	struct chroma_key_params
+	{
+		bool enabled = false;
+		std::array<float, 3> hsv_min{0.f, 0.f, 0.f};
+		std::array<float, 3> hsv_max{1.f, 1.f, 1.f};
+		float curve = 0.f;
+		float despill = 0.f;
+	};
+
+private:
 	struct vertex;
 	static const uint32_t view_count = 2;
 	// Vertex buffer
@@ -89,6 +103,7 @@ public:
 	        const std::array<input, 2> & inputs,
 	        std::array<float, 4> scale,
 	        std::array<float, 4> bias,
+	        const chroma_key_params & chroma_key,
 	        int destination);
 
 	static XrExtent2Di defoveated_size(const wivrn::to_headset::foveation_parameter &);

--- a/client/scenes/stream_defoveator.h
+++ b/client/scenes/stream_defoveator.h
@@ -39,6 +39,15 @@ public:
 		float despill = 0.f;
 	};
 
+	// Parameters for the sunglasses tint. Colour is already converted to
+	// linear RGB by the caller so the shader only needs a mix().
+	struct sunglasses_params
+	{
+		bool enabled = false;
+		std::array<float, 3> rgb{0.f, 0.f, 0.f};
+		float alpha = 0.f;
+	};
+
 private:
 	struct vertex;
 	static const uint32_t view_count = 2;
@@ -104,6 +113,7 @@ public:
 	        std::array<float, 4> scale,
 	        std::array<float, 4> bias,
 	        const chroma_key_params & chroma_key,
+	        const sunglasses_params & sunglasses,
 	        int destination);
 
 	static XrExtent2Di defoveated_size(const wivrn::to_headset::foveation_parameter &);

--- a/client/scenes/stream_gui.cpp
+++ b/client/scenes/stream_gui.cpp
@@ -588,6 +588,60 @@ void scenes::stream::gui_settings(float predicted_display_period)
 	}
 	ImGui::Unindent();
 
+	// Sunglasses: dim the stream with a solid colour overlay.
+	ImGui::Text("%s", _S("Sunglasses"));
+	ImGui::Indent();
+	{
+		auto & sg = config.sunglasses;
+		bool sg_dirty = false;
+		if (ImGui::Checkbox(_S("Enable sunglasses"), &sg.enabled))
+			sg_dirty = true;
+		imgui_ctx->vibrate_on_hover();
+		if (ImGui::IsItemHovered())
+			imgui_ctx->tooltip(_("Blend a solid color over the stream to dim it.\nPassthrough regions keep their real brightness."));
+
+		ImGui::BeginDisabled(!sg.enabled);
+		if (ImGui::SliderFloat(_S("Hue"), &sg.hsv[0], 0.f, 1.f, "%.3f"))
+			sg_dirty = true;
+		imgui_ctx->vibrate_on_hover();
+
+		if (ImGui::SliderFloat(_S("Saturation"), &sg.hsv[1], 0.f, 1.f, "%.3f"))
+			sg_dirty = true;
+		imgui_ctx->vibrate_on_hover();
+
+		if (ImGui::SliderFloat(_S("Value"), &sg.hsv[2], 0.f, 1.f, "%.3f"))
+			sg_dirty = true;
+		imgui_ctx->vibrate_on_hover();
+		if (ImGui::IsItemHovered())
+			imgui_ctx->tooltip(_("Brightness of the tint color. Keep at 0 for pure dimming."));
+
+		if (ImGui::SliderFloat(_S("Opacity"), &sg.alpha, 0.f, 1.f, "%.3f"))
+			sg_dirty = true;
+		imgui_ctx->vibrate_on_hover();
+		if (ImGui::IsItemHovered())
+			imgui_ctx->tooltip(_("How strongly the color covers the image: 0 = invisible, 1 = fully opaque."));
+
+		{
+			ImGui::Text("%s", _S("Tint color preview"));
+			float r, g, b;
+			ImGui::ColorConvertHSVtoRGB(sg.hsv[0], sg.hsv[1], sg.hsv[2], r, g, b);
+			const float height = ImGui::GetFrameHeight();
+			ImGui::ColorButton("##sunglasses_tint", ImVec4(r, g, b, 1), ImGuiColorEditFlags_NoTooltip | ImGuiColorEditFlags_NoDragDrop, ImVec2(height * 2, height));
+		}
+
+		if (ImGui::Button(_S("Reset sunglasses")))
+		{
+			sg = configuration::sunglasses_settings{};
+			sg_dirty = true;
+		}
+		imgui_ctx->vibrate_on_hover();
+		ImGui::EndDisabled();
+
+		if (sg_dirty)
+			config.save();
+	}
+	ImGui::Unindent();
+
 	ImGui::PopStyleVar();
 }
 

--- a/client/scenes/stream_gui.cpp
+++ b/client/scenes/stream_gui.cpp
@@ -526,6 +526,51 @@ void scenes::stream::gui_settings(float predicted_display_period)
 		if (ImGui::IsItemHovered())
 			imgui_ctx->tooltip(_("Reduce the key color tinting remaining pixels (useful for green screens)."));
 
+		// Preview: hue bar with the keyed range shown saturated, the rest dimmed,
+		// plus a swatch of the centre of the selected HSV range.
+		{
+			ImGui::Text("%s", _S("Key color preview"));
+			const float h_min = ck.hsv_min[0];
+			const float h_max = ck.hsv_max[0];
+			const bool wrap = h_min > h_max;
+
+			float h_center = wrap
+			                         ? std::fmod(h_min + std::fmod(h_max - h_min + 1.f, 1.f) * 0.5f, 1.f)
+			                         : 0.5f * (h_min + h_max);
+			float r, g, b;
+			ImGui::ColorConvertHSVtoRGB(h_center,
+			                            0.5f * (ck.hsv_min[1] + ck.hsv_max[1]),
+			                            0.5f * (ck.hsv_min[2] + ck.hsv_max[2]),
+			                            r,
+			                            g,
+			                            b);
+			const float height = ImGui::GetFrameHeight();
+			ImGui::ColorButton("##chroma_key_center", ImVec4(r, g, b, 1), ImGuiColorEditFlags_NoTooltip | ImGuiColorEditFlags_NoDragDrop, ImVec2(height * 2, height));
+			ImGui::SameLine();
+
+			ImDrawList * draw_list = ImGui::GetWindowDrawList();
+			const ImVec2 pos = ImGui::GetCursorScreenPos();
+			const float width = ImGui::GetContentRegionAvail().x;
+			const int segments = 64;
+			for (int i = 0; i < segments; ++i)
+			{
+				const float h0 = float(i) / segments;
+				const float h1 = float(i + 1) / segments;
+				const float h = 0.5f * (h0 + h1);
+				const bool inside = wrap ? (h >= h_min or h <= h_max) : (h >= h_min and h <= h_max);
+				ImGui::ColorConvertHSVtoRGB(h,
+				                            inside ? ck.hsv_max[1] : 0.25f,
+				                            inside ? ck.hsv_max[2] : 0.35f,
+				                            r,
+				                            g,
+				                            b);
+				draw_list->AddRectFilled(ImVec2(pos.x + width * h0, pos.y),
+				                         ImVec2(pos.x + width * h1, pos.y + height),
+				                         ImGui::ColorConvertFloat4ToU32(ImVec4(r, g, b, 1)));
+			}
+			ImGui::Dummy(ImVec2(width, height));
+		}
+
 		if (ImGui::Button(_S("Reset chroma key")))
 		{
 			ck = configuration::chroma_key_settings{};

--- a/client/scenes/stream_gui.cpp
+++ b/client/scenes/stream_gui.cpp
@@ -475,6 +475,74 @@ void scenes::stream::gui_settings(float predicted_display_period)
 		config.override_foveation_distance = override_foveation_distance;
 		config.save();
 	}
+
+	// Chroma key passthrough (ALVR-style, client-side).
+	ImGui::Text("%s", _S("Chroma key passthrough"));
+	ImGui::Indent();
+	{
+		auto & ck = config.chroma_key;
+		const bool passthrough_supported = system.passthrough_supported() != xr::passthrough_type::none;
+		ImGui::BeginDisabled(!passthrough_supported);
+		bool ck_dirty = false;
+		if (ImGui::Checkbox(_S("Enable chroma key"), &ck.enabled))
+			ck_dirty = true;
+		imgui_ctx->vibrate_on_hover();
+		if (ImGui::IsItemHovered())
+			imgui_ctx->tooltip(_("Replace pixels inside the HSV range below with the passthrough view.\nApplies to any running application, even when it does not output alpha."));
+
+		ImGui::BeginDisabled(!ck.enabled);
+		if (ImGui::SliderFloat(_S("Hue min"), &ck.hsv_min[0], 0.f, 1.f, "%.3f"))
+			ck_dirty = true;
+		imgui_ctx->vibrate_on_hover();
+		if (ImGui::SliderFloat(_S("Hue max"), &ck.hsv_max[0], 0.f, 1.f, "%.3f"))
+			ck_dirty = true;
+		imgui_ctx->vibrate_on_hover();
+		if (ImGui::IsItemHovered())
+			imgui_ctx->tooltip(_("Hue range. If min > max the range wraps around 0/1 (useful for reds)."));
+
+		if (ImGui::SliderFloat(_S("Saturation min"), &ck.hsv_min[1], 0.f, 1.f, "%.3f"))
+			ck_dirty = true;
+		imgui_ctx->vibrate_on_hover();
+		if (ImGui::SliderFloat(_S("Saturation max"), &ck.hsv_max[1], 0.f, 1.f, "%.3f"))
+			ck_dirty = true;
+		imgui_ctx->vibrate_on_hover();
+
+		if (ImGui::SliderFloat(_S("Value min"), &ck.hsv_min[2], 0.f, 1.f, "%.3f"))
+			ck_dirty = true;
+		imgui_ctx->vibrate_on_hover();
+		if (ImGui::SliderFloat(_S("Value max"), &ck.hsv_max[2], 0.f, 1.f, "%.3f"))
+			ck_dirty = true;
+		imgui_ctx->vibrate_on_hover();
+
+		if (ImGui::SliderFloat(_S("Softness"), &ck.curve, 0.f, 0.5f, "%.3f"))
+			ck_dirty = true;
+		imgui_ctx->vibrate_on_hover();
+		if (ImGui::IsItemHovered())
+			imgui_ctx->tooltip(_("Feathering width around the HSV range. Larger values blend the edges more smoothly."));
+
+		if (ImGui::SliderFloat(_S("Despill"), &ck.despill, 0.f, 1.f, "%.2f"))
+			ck_dirty = true;
+		imgui_ctx->vibrate_on_hover();
+		if (ImGui::IsItemHovered())
+			imgui_ctx->tooltip(_("Reduce the key color tinting remaining pixels (useful for green screens)."));
+
+		if (ImGui::Button(_S("Reset chroma key")))
+		{
+			ck = configuration::chroma_key_settings{};
+			ck_dirty = true;
+		}
+		imgui_ctx->vibrate_on_hover();
+		ImGui::EndDisabled();
+
+		if (ck_dirty)
+			config.save();
+		ImGui::EndDisabled();
+
+		if (!passthrough_supported)
+			ImGui::TextDisabled("%s", _S("Passthrough not supported on this headset"));
+	}
+	ImGui::Unindent();
+
 	ImGui::PopStyleVar();
 }
 

--- a/client/shaders/reprojection.glsl
+++ b/client/shaders/reprojection.glsl
@@ -30,6 +30,10 @@ layout(push_constant) uniform pc
 	vec4 chroma_key_params;
 	vec4 chroma_key_hsv_min; // xyz = HSV min, w unused
 	vec4 chroma_key_hsv_max; // xyz = HSV max, w unused
+	// Sunglasses tint: xyz = sRGB colour, w = blend strength (0 disables).
+	// Adding this vec4 brings the block to exactly the 128-byte Vulkan
+	// push constant minimum.
+	vec4 sunglasses_tint;
 };
 
 #define chroma_key_enabled (chroma_key_params.x > 0.5)
@@ -188,6 +192,16 @@ void main()
 		outColor.rgb /= outColor.a;
 		outColor = outColor * scale + bias;
 		outColor.rgb *= outColor.a;
+	}
+
+	if (sunglasses_tint.w > 0)
+	{
+		vec3 tint = sunglasses_tint.rgb;
+		if (do_srgb)
+			tint = sRGB_to_linear_rgba(vec4(tint, 1.0)).rgb;
+		// Multiply by outColor.a to keep premultiplied alpha: transparent
+		// (passthrough) regions stay untinted.
+		outColor.rgb = mix(outColor.rgb, tint * outColor.a, sunglasses_tint.w);
 	}
 }
 

--- a/client/shaders/reprojection.glsl
+++ b/client/shaders/reprojection.glsl
@@ -24,7 +24,17 @@ layout(push_constant) uniform pc
 	ivec4 a_rect;
 	vec4 scale;
 	vec4 bias;
+	// Client-side chroma key passthrough. Packed into 3 vec4s to stay well
+	// under the 128-byte Vulkan push constant minimum.
+	//   x = enabled (0/1), y = curve, z = despill, w = reserved.
+	vec4 chroma_key_params;
+	vec4 chroma_key_hsv_min; // xyz = HSV min, w unused
+	vec4 chroma_key_hsv_max; // xyz = HSV max, w unused
 };
+
+#define chroma_key_enabled (chroma_key_params.x > 0.5)
+#define chroma_key_curve   chroma_key_params.y
+#define chroma_key_despill chroma_key_params.z
 
 #ifdef VERT_SHADER
 
@@ -69,6 +79,72 @@ vec4 sRGB_to_linear_rgba(vec4 x)
 	        x.a);
 }
 
+// Standard RGB -> HSV conversion (Sam Hocevar's trick).
+vec3 rgb_to_hsv(vec3 c)
+{
+	vec4 K = vec4(0.0, -1.0/3.0, 2.0/3.0, -1.0);
+	vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));
+	vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));
+	float d = q.x - min(q.w, q.y);
+	float e = 1.0e-10;
+	return vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)),
+	            d / (q.x + e),
+	            q.x);
+}
+
+// Hue is circular: if min.h > max.h the range wraps around 0/1.
+float hue_in_range(float h, float hmin, float hmax, float soft)
+{
+	if (hmin <= hmax)
+	{
+		float lo = smoothstep(hmin - soft, hmin, h);
+		float hi = 1.0 - smoothstep(hmax, hmax + soft, h);
+		return lo * hi;
+	}
+	else
+	{
+		float lo = smoothstep(hmin - soft, hmin, h);
+		float hi = 1.0 - smoothstep(hmax, hmax + soft, h);
+		return max(lo, hi);
+	}
+}
+
+// Returns 1.0 when the pixel should be kept, 0.0 when it should be keyed out.
+float chroma_key_mask(vec3 rgb_sample)
+{
+	vec3 hsv = rgb_to_hsv(rgb_sample);
+	float soft = max(chroma_key_curve, 1.0e-4);
+	float h = hue_in_range(hsv.x, chroma_key_hsv_min.x, chroma_key_hsv_max.x, soft);
+	float s = smoothstep(chroma_key_hsv_min.y - soft, chroma_key_hsv_min.y, hsv.y)
+	        * (1.0 - smoothstep(chroma_key_hsv_max.y, chroma_key_hsv_max.y + soft, hsv.y));
+	float v = smoothstep(chroma_key_hsv_min.z - soft, chroma_key_hsv_min.z, hsv.z)
+	        * (1.0 - smoothstep(chroma_key_hsv_max.z, chroma_key_hsv_max.z + soft, hsv.z));
+	// All three must be inside the range (product) to count as keyed.
+	float inside = h * s * v;
+	return 1.0 - inside;
+}
+
+// Reduce residual spill of the key color (typically green) on kept pixels.
+vec3 despill(vec3 c)
+{
+	if (chroma_key_despill <= 0.0)
+		return c;
+	// Use the midpoint of the HSV hue range as the key hue.
+	float hmin = chroma_key_hsv_min.x;
+	float hmax = chroma_key_hsv_max.x;
+	float hkey = (hmax >= hmin) ? 0.5 * (hmin + hmax) : fract(0.5 * (hmin + hmax + 1.0));
+	// Map hue in [0, 1] to a color channel emphasis: green around 1/3, red 0, blue 2/3.
+	// Simple subtractive desaturation: clamp the key channel to the average of the others.
+	vec3 limit;
+	if (hkey < 1.0/6.0 || hkey >= 5.0/6.0)
+		limit = vec3(0.5 * (c.g + c.b), c.g, c.b); // red key
+	else if (hkey < 0.5)
+		limit = vec3(c.r, 0.5 * (c.r + c.b), c.b); // green key
+	else
+		limit = vec3(c.r, c.g, 0.5 * (c.r + c.g)); // blue key
+	return mix(c, min(c, limit), clamp(chroma_key_despill, 0.0, 1.0));
+}
+
 void main()
 {
 	if (alpha == 1)
@@ -88,7 +164,18 @@ void main()
 		outColor = sRGB_to_linear_rgba(outColor);
 	}
 
-	if (alpha == 0)
+	// Apply chroma key only when the stream has no real alpha channel.
+	// When the app itself provides alpha (alpha == 1) we trust it and avoid
+	// double-masking.
+	bool ck_active = (alpha == 0) && chroma_key_enabled;
+	if (ck_active)
+	{
+		float m = chroma_key_mask(outColor.rgb);
+		outColor.rgb = despill(outColor.rgb);
+		outColor.a = m;
+	}
+
+	if (alpha == 0 && !ck_active)
 	{
 		outColor = outColor * scale + bias;
 	}

--- a/client/wifi_lock.cpp
+++ b/client/wifi_lock.cpp
@@ -23,6 +23,7 @@
 #include "application.h"
 #include "spdlog/spdlog.h"
 #include <android/native_activity.h>
+#include <mutex>
 #include <sys/system_properties.h>
 
 #include "android/jnipp.h"

--- a/client/wivrn_discover.cpp
+++ b/client/wivrn_discover.cpp
@@ -5,6 +5,7 @@
 #include "utils/named_thread.h"
 #include <arpa/inet.h>
 #include <ifaddrs.h>
+#include <mutex>
 #include <net/if.h>
 #include <poll.h>
 #include <spdlog/spdlog.h>

--- a/common/wivrn_sockets.cpp
+++ b/common/wivrn_sockets.cpp
@@ -24,6 +24,7 @@
 #include <arpa/inet.h>
 #include <cassert>
 #include <memory>
+#include <mutex>
 #include <netdb.h>
 #include <netinet/ip.h>
 #include <netinet/tcp.h>


### PR DESCRIPTION
Adds a "sunglasses" mode to the client: a solid, HSV-selected colour is blended over the decoded stream with a configurable opacity, dimming the whole image (default colour is black, i.e. pure dimming). Useful to reduce eye strain in bright VR content.

Stacked on #1037 (chroma key passthrough) — the implementation mirrors its data path exactly and the code depends on it. Until #1037 merges, this PR's diff also shows its commits; only the last two commits are new here.

## Implementation

- `configuration.{h,cpp}`: new `sunglasses_settings` (enabled / HSV / alpha), persisted in `client.json` under `"sunglasses"`.
- `scenes/stream.cpp`: converts HSV to RGB on the CPU each frame and passes `sunglasses_params` to the defoveator.
- `scenes/stream_defoveator.{h,cpp}`: one extra `vec4 sunglasses_tint` push constant (xyz = RGB, w = opacity, 0 when disabled). The push constant block is now exactly 128 bytes — at the Vulkan guaranteed minimum.
- `shaders/reprojection.glsl`: applied at the end of `main()` as `mix(outColor.rgb, tint * outColor.a, opacity)`. Multiplying by `outColor.a` keeps premultiplied alpha intact, so chroma-keyed passthrough regions keep their real brightness. On sRGB swapchains the tint is converted to linear first.
- `scenes/stream_gui.cpp`: new "Sunglasses" section under the chroma key settings — enable checkbox, Hue/Saturation/Value/Opacity sliders, colour preview swatch, reset button; changes save immediately.

Also includes a standalone build fix for GCC 16 / recent OpenXR headers (missing `<mutex>` includes; `XR_META_body_tracking_fidelity` redefinition guard) needed to build this branch on an up-to-date toolchain.

## Design notes

- Client-side only; no protocol change (`wivrn_packets.h` untouched), works with any server.
- Passthrough regions are intentionally not tinted — only virtual content is dimmed.

## Testing

- Builds clean on Linux (native client + server, GCC 16.1.1) and Android (`assembleRelease`).
- Verified on device (Quest 3, server and client built from this tree): full-screen dimming with the opacity slider, HSV colour response matching the preview swatch, settings persisted across restarts, no regression with chroma key on or off (passthrough regions keep their real brightness).


https://github.com/user-attachments/assets/a4ac52f0-540c-4f32-84a9-2b22c10fd42e




