### PR TITLE
fix(ci): bump pinned Vulkan SDK to 1.4.328.1

### DIFF
--- a/.github/workflows/APK-Release.yml
+++ b/.github/workflows/APK-Release.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Prepare Vulkan SDK
       uses: humbletim/setup-vulkan-sdk@v1.2.1
       with:
-        vulkan-query-version: 1.3.296.0
+        vulkan-query-version: 1.4.328.1
         vulkan-components: Glslang, SPIRV-Tools
         vulkan-use-cache: true
 

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -72,7 +72,7 @@ jobs:
     - name: Prepare Vulkan SDK
       uses: humbletim/setup-vulkan-sdk@v1.2.1
       with:
-        vulkan-query-version: 1.3.296.0
+        vulkan-query-version: 1.4.328.1
         vulkan-components: Vulkan-Headers, Vulkan-Loader, Glslang, SPIRV-Reflect, SPIRV-Tools
         vulkan-use-cache: true
 
@@ -195,7 +195,7 @@ jobs:
     - name: Prepare Vulkan SDK
       uses: humbletim/setup-vulkan-sdk@v1.2.1
       with:
-        vulkan-query-version: 1.3.296.0
+        vulkan-query-version: 1.4.328.1
         vulkan-components: Glslang, SPIRV-Tools
         vulkan-use-cache: true
 


### PR DESCRIPTION
The Linux matrix moved to ubuntu-26.04, which has GCC >= 14 and CMake >= 3.28. Vulkan-Headers at vulkan-sdk-1.3.296.0 defaults VULKAN_HEADERS_ENABLE_MODULE to ${COMPILER_SUPPORTS_CXX_MODULES}, so that combination creates a CXX_MODULES target and the from-source SDK build fails at generate time:

> The target named "Vulkan-Module" has C++ sources that may use modules, but modules are not supported by this generator: Unix Makefiles

From vulkan-sdk-1.4.304.1 on, the option is opt-in (defaults to OFF), so the module target is never created.

Pin 1.4.328.1, the tag already used for SPIRV-Reflect in CMakeLists.txt.