### PR TITLE
feat(vulkan): use distro Vulkan packages in CI instead of setup-vulkan-sdk 

### DIFF
--- a/.github/workflows/APK-Release.yml
+++ b/.github/workflows/APK-Release.yml
@@ -25,6 +25,15 @@ jobs:
         ref: ${{ github.sha }}
         fetch-depth: 0
 
+    # Gradle distribution and the Android plugin's dependencies.
+    - uses: actions/cache@v5
+      with:
+        key: gradle-android-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties', 'build.gradle') }}
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        restore-keys: gradle-android-
+
     - name: Install dependencies
       run: |
         sudo apt-get update && sudo apt-get install glslang-tools spirv-tools librsvg2-bin gettext npm

--- a/.github/workflows/APK-Release.yml
+++ b/.github/workflows/APK-Release.yml
@@ -25,16 +25,9 @@ jobs:
         ref: ${{ github.sha }}
         fetch-depth: 0
 
-    - name: Prepare Vulkan SDK
-      uses: humbletim/setup-vulkan-sdk@v1.2.1
-      with:
-        vulkan-query-version: 1.3.296.0
-        vulkan-components: Glslang, SPIRV-Tools
-        vulkan-use-cache: true
-
     - name: Install dependencies
       run: |
-        sudo apt-get update && sudo apt-get install glslang-tools librsvg2-bin gettext npm
+        sudo apt-get update && sudo apt-get install glslang-tools spirv-tools librsvg2-bin gettext npm
         wget https://github.com/KhronosGroup/KTX-Software/releases/download/v4.4.0/KTX-Software-4.4.0-Linux-x86_64.deb
         sudo dpkg --install KTX-Software-4.4.0-Linux-x86_64.deb
         npm install --global @gltf-transform/cli@4.1.1

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -30,7 +30,6 @@ jobs:
         # Perfetto SDK glue don't bitrot (WIVRN_TRACE_MONADO needs percetto, not packaged in CI)
           - preset: 'server-tracing'
             packages: libboost-all-dev libsystemd-dev
-            perfetto: true
           - preset: 'server-no-systemd'
             packages: libboost-all-dev
           - preset: 'server-no-system-boost'
@@ -42,7 +41,7 @@ jobs:
     - name: Apt dependencies
       uses: awalsh128/cache-apt-pkgs-action@v1.6.1
       with:
-        packages: ccache ${{matrix.config.packages}} ${{ startsWith(matrix.config.preset, 'server') && env.SERVER_DEPS || ''}}
+        packages: ccache libvulkan-dev glslang-tools spirv-tools libwayland-dev libxrandr-dev ${{matrix.config.packages}} ${{ startsWith(matrix.config.preset, 'server') && env.SERVER_DEPS || ''}}
 
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2.23
@@ -69,15 +68,8 @@ jobs:
         sudo dpkg --install KTX-Software-4.4.2-Linux-x86_64.deb
         npm install --global @gltf-transform/cli@4.1.1
 
-    - name: Prepare Vulkan SDK
-      uses: humbletim/setup-vulkan-sdk@v1.2.1
-      with:
-        vulkan-query-version: 1.3.296.0
-        vulkan-components: Vulkan-Headers, Vulkan-Loader, Glslang, SPIRV-Reflect, SPIRV-Tools
-        vulkan-use-cache: true
-
     - name: Fetch Perfetto SDK
-      if: ${{ matrix.config.perfetto }}
+      if: ${{ matrix.config.preset == 'server-tracing' }}
       # The amalgamated SDK is two files; install them where server/CMakeLists.txt looks.
       env:
         PERFETTO_TAG: v51.0
@@ -192,13 +184,6 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Prepare Vulkan SDK
-      uses: humbletim/setup-vulkan-sdk@v1.2.1
-      with:
-        vulkan-query-version: 1.3.296.0
-        vulkan-components: Glslang, SPIRV-Tools
-        vulkan-use-cache: true
-
     - uses: actions/cache@v5
       with:
         key: cmake-android-${{matrix.buildtype}}
@@ -212,7 +197,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt-get update && sudo apt-get install glslang-tools librsvg2-bin gettext
+        sudo apt-get update && sudo apt-get install glslang-tools spirv-tools librsvg2-bin gettext
         wget https://github.com/KhronosGroup/KTX-Software/releases/download/v4.3.2/KTX-Software-4.3.2-Linux-x86_64.deb
         sudo dpkg --install KTX-Software-4.3.2-Linux-x86_64.deb
         npm install --global @gltf-transform/cli

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -122,7 +122,8 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ vars.APK_ONLY == '' }}
     container:
-      image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.9
+      # Tag matches runtime-version in the manifest.
+      image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.10
       options: --privileged
 
     steps:

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -196,6 +196,15 @@ jobs:
           ${{github.workspace}}/cmake-fetch/*.tgz
         restore-keys: cmake-android-
 
+    # Gradle distribution and the Android plugin's dependencies.
+    - uses: actions/cache@v5
+      with:
+        key: gradle-android-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties', 'build.gradle') }}
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        restore-keys: gradle-android-
+
     - name: Install dependencies
       run: |
         sudo apt-get update && sudo apt-get install glslang-tools spirv-tools librsvg2-bin gettext

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,8 +123,8 @@ endif()
 
 if (WIVRN_BUILD_SERVER)
     find_program(GDBUS_CODEGEN gdbus-codegen REQUIRED)
-    if (Vulkan_VERSION  VERSION_LESS "1.3.261")
-        message(FATAL_ERROR "Vulkan version must be at least 1.3.261, found ${Vulkan_VERSION}")
+    if (Vulkan_VERSION  VERSION_LESS "1.4.304")
+        message(FATAL_ERROR "Vulkan version must be at least 1.4.304, found ${Vulkan_VERSION}")
     endif()
 
     if (NOT WIVRN_USE_NVENC AND NOT WIVRN_USE_VAAPI AND NOT WIVRN_USE_X264 AND NOT WIVRN_USE_VULKAN_ENCODE)
@@ -134,12 +134,6 @@ if (WIVRN_BUILD_SERVER)
     if (WIVRN_USE_VAAPI)
         pkg_check_modules(LIBAV REQUIRED IMPORTED_TARGET libavcodec libavutil)
         pkg_check_modules(LIBDRM REQUIRED IMPORTED_TARGET libdrm)
-    endif()
-
-    if (WIVRN_USE_VULKAN_ENCODE)
-        if (Vulkan_VERSION VERSION_LESS 1.3.283)
-            message(FATAL_ERROR "Vulkan video encode requires 1.3.283, found ${Vulkan_VERSION}")
-        endif()
     endif()
 
     if (WIVRN_USE_X264)

--- a/debian/control
+++ b/debian/control
@@ -29,7 +29,7 @@ Build-Depends:
  libsystemd-dev,
  libudev-dev,
  libva-dev,
- libvulkan-dev (>= 1.3.261),
+ libvulkan-dev (>= 1.4.304),
  libwayland-dev,
  libx11-xcb-dev,
  libx264-dev,

--- a/flatpak/io.github.wivrn.wivrn.yml.in
+++ b/flatpak/io.github.wivrn.wivrn.yml.in
@@ -102,8 +102,11 @@ modules:
 
   - name: toolchain
     sources:
+    # mirror-urls are fallbacks, used when the primary url fails.
     - type: file
       url: https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.15.177.tar.xz
+      mirror-urls:
+        - https://mirrors.edge.kernel.org/pub/linux/kernel/v5.x/linux-5.15.177.tar.xz
       sha256: ea9eb8088d4231f8a01b191ceef5f4d92238f6c7519f6fbcb57e448ee9e0a6e0
     - type: file
       url: https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.xz
@@ -113,34 +116,63 @@ modules:
       sha256: 8c29e06cf42aacc1eafc4077ae2ec6c6fcb96a626157e0593d5e82a34fd403c1
     - type: file
       url: https://ftpmirror.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz
+      mirror-urls:
+        - https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz
+        - https://mirrors.kernel.org/gnu/gmp/gmp-6.3.0.tar.xz
       sha256: a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898
     - type: file
       url: https://www.mpfr.org/mpfr-4.2.1/mpfr-4.2.1.tar.xz
+      mirror-urls:
+        - https://ftp.gnu.org/gnu/mpfr/mpfr-4.2.1.tar.xz
+        - https://mirrors.kernel.org/gnu/mpfr/mpfr-4.2.1.tar.xz
       sha256: 277807353a6726978996945af13e52829e3abd7a9a5b7fb2793894e18f1fcbb2
     - type: file
       dest-filename: isl-0.26.tar.xz
       url: https://sourceforge.net/projects/libisl/files/isl-0.26.tar.xz/download
+      mirror-urls:
+        - https://libisl.sourceforge.io/isl-0.26.tar.xz
       sha256: a0b5cb06d24f9fa9e77b55fabbe9a3c94a336190345c2555f9915bb38e976504
     - type: file
       url: https://ftpmirror.gnu.org/gnu/mpc/mpc-1.3.1.tar.gz
+      mirror-urls:
+        - https://ftp.gnu.org/gnu/mpc/mpc-1.3.1.tar.gz
+        - https://mirrors.kernel.org/gnu/mpc/mpc-1.3.1.tar.gz
       sha256: ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8
     - type: file
       url: https://invisible-mirror.net/archives/ncurses/ncurses-6.4.tar.gz
+      mirror-urls:
+        - https://ftp.gnu.org/gnu/ncurses/ncurses-6.4.tar.gz
+        - https://mirrors.kernel.org/gnu/ncurses/ncurses-6.4.tar.gz
       sha256: 6931283d9ac87c5073f30b6290c4c75f21632bb4fc3603ac8100812bed248159
     - type: file
       url: https://ftpmirror.gnu.org/gnu/libiconv/libiconv-1.16.tar.gz
+      mirror-urls:
+        - https://ftp.gnu.org/gnu/libiconv/libiconv-1.16.tar.gz
+        - https://mirrors.kernel.org/gnu/libiconv/libiconv-1.16.tar.gz
       sha256: e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04
     - type: file
       url: https://ftpmirror.gnu.org/gnu/gettext/gettext-0.23.1.tar.xz
+      mirror-urls:
+        - https://ftp.gnu.org/gnu/gettext/gettext-0.23.1.tar.xz
+        - https://mirrors.kernel.org/gnu/gettext/gettext-0.23.1.tar.xz
       sha256: c1f97a72a7385b7e71dd07b5fea6cdaf12c9b88b564976b23bd8c11857af2970
     - type: file
       url: https://ftpmirror.gnu.org/gnu/binutils/binutils-2.43.1.tar.xz
+      mirror-urls:
+        - https://ftp.gnu.org/gnu/binutils/binutils-2.43.1.tar.xz
+        - https://mirrors.kernel.org/gnu/binutils/binutils-2.43.1.tar.xz
       sha256: 13f74202a3c4c51118b797a39ea4200d3f6cfbe224da6d1d95bb938480132dfd
     - type: file
       url: https://ftpmirror.gnu.org/gnu/gcc/gcc-11.5.0/gcc-11.5.0.tar.xz
+      mirror-urls:
+        - https://ftp.gnu.org/gnu/gcc/gcc-11.5.0/gcc-11.5.0.tar.xz
+        - https://mirrors.kernel.org/gnu/gcc/gcc-11.5.0/gcc-11.5.0.tar.xz
       sha256: a6e21868ead545cf87f0c01f84276e4b5281d672098591c1c896241f09363478
     - type: file
       url: https://ftpmirror.gnu.org/gnu/glibc/glibc-2.35.tar.xz
+      mirror-urls:
+        - https://ftp.gnu.org/gnu/glibc/glibc-2.35.tar.xz
+        - https://mirrors.kernel.org/gnu/glibc/glibc-2.35.tar.xz
       sha256: 5123732f6b67ccd319305efd399971d58592122bcc2a6518a1bd2510dd0cf52e
     - type: file
       path: ct-ng-x86_64.config

--- a/server/utils/wivrn_vk_bundle.cpp
+++ b/server/utils/wivrn_vk_bundle.cpp
@@ -36,15 +36,9 @@ namespace
 {
 
 VkBool32 message_callback(
-#if VK_HEADER_VERSION >= 304
         vk::DebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
         vk::DebugUtilsMessageTypeFlagsEXT messageTypes,
         const vk::DebugUtilsMessengerCallbackDataEXT * pCallbackData,
-#else
-        VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
-        VkDebugUtilsMessageTypeFlagsEXT messageTypes,
-        const VkDebugUtilsMessengerCallbackDataEXT * pCallbackData,
-#endif
         void * pUserData)
 {
 	u_logging_level level = U_LOGGING_ERROR;


### PR DESCRIPTION
 Fixes CI on ubuntu-26.04 and stops three jobs refetching their dependencies every run.

 - Vulkan: use Ubuntu's libvulkan-dev / glslang-tools / spirv-tools instead of building the SDK from source with setup-vulkan-sdk, which fails on ubuntu-26.04 (Vulkan-Headers 1.3.296 defines a C++20 module target, unsupported by the Unix Makefiles generator). Server now requires Vulkan 1.4.304 — what every CI platform ships, Debian 13 / Ubuntu 25.04+ — which subsumes the 1.3.283 video-encode check and the server-side VK_HEADER_VERSION >= 304 branch.

 - flatpak: cache .flatpak-builder with restore-keys and save it on failure, drop CMakeLists.txt from the key, pre-fetch sources with retries, add mirror-urls to the toolchain tarballs, and use the container image matching the manifest's runtime version. A dead ftpmirror.gnu.org mirror was failing the job outright; build step 3008s → 595s on a cache hit.
 
- Android: cache ~/.gradle, so a Maven Central 403 no longer fails the build before it configures.