### PR TITLE
assign xrt_device::id's

### DIFF
--- a/server/driver/wivrn_session.cpp
+++ b/server/driver/wivrn_session.cpp
@@ -47,6 +47,7 @@
 #include "b_hand_tracker.h"
 #include "b_system.h"
 #include "target_builder_helpers.h"
+#include "util/u_device_id.h"
 #include "util/u_logging.h"
 #include "xrt/xrt_defines.h"
 #include "xrt/xrt_device.h"
@@ -250,6 +251,12 @@ wivrn::wivrn_session::wivrn_session(std::unique_ptr<wivrn_connection> connection
 		roles.right_profile = static_xdevs[roles.right]->name;
 	if (roles.gamepad >= 0)
 		roles.gamepad_profile = static_xdevs[roles.gamepad]->name;
+
+	for (uint32_t i = 0; i < static_xdev_count; ++i)
+	{
+		if (static_xdevs[i]->id.val == 0)
+			u_device_id_assign(static_xdevs[i]);
+	}
 
 	if (auto system_name = get_info().system_name; !system_name.empty())
 	{


### PR DESCRIPTION
Necessary for Monado changes:

https://gitlab.freedesktop.org/monado/monado/-/commit/468a06d73ed9e00a7195d99c32424522e96dd5a7

https://gitlab.freedesktop.org/monado/monado/-/commit/4362f92ef6e831088b306fe8ef4c5775b358ab1d

> A limited unique id, it is only unique for the process it is in, so must not be
> used or synchronized across process boundaries. A value of zero is invalid
> and means it has not be properly initialised.