### PR TITLE
add slider for LH_STICK_DEADZONE

### DIFF
--- a/dashboard/qml/SettingsPage.qml
+++ b/dashboard/qml/SettingsPage.qml
@@ -132,6 +132,26 @@ Kirigami.ScrollablePage {
                     toolTipText: i18n("Allows the use of lighthouse-based controllers and trackers.\nRequires SteamVR to be installed.\nDevices must be be powered on before connecting to WiVRn.\nAn external tool such as motoc is needed for calibration.")
                 }
             }
+            RowLayout {
+                visible: Settings.steamvr_lh_supported && steamvr_lh.checked
+                Kirigami.FormData.label: i18n("SteamVR joystick deadzone")
+                Controls.Slider {
+                    id: lh_stick_deadzone
+                    Layout.fillWidth: true
+                    from: 0.0
+                    to: 0.9
+                    stepSize: 0.05
+                    value: Settings.lhStickDeadzone
+                }
+                Controls.Label {
+                    text: lh_stick_deadzone.value.toFixed(2)
+                    Layout.preferredWidth: 35
+                    Layout.alignment: Qt.AlignRight
+                }
+                Kirigami.ContextualHelpButton {
+                    toolTipText: i18n("Deadzone to apply to joysticks on lighthouse-tracked controllers, such as Index.\nFor standalone controllers, deadzones may be adjusted via the headset's system settings.")
+                }
+            }
 
             Controls.CheckBox {
                 id: adb_custom
@@ -289,6 +309,7 @@ Kirigami.ScrollablePage {
 
         Settings.debugGui = debug_gui.checked;
         Settings.steamVrLh = steamvr_lh.checked;
+        Settings.lhStickDeadzone = lh_stick_deadzone.value;
         Settings.hidForwarding = hid_forwarding.checked;
 
         DashboardSettings.auto_connect_usb = auto_connect_usb.checked;
@@ -298,6 +319,7 @@ Kirigami.ScrollablePage {
         select_game.load();
         debug_gui.checked = Settings.debugGui;
         steamvr_lh.checked = Settings.steamVrLh;
+        lh_stick_deadzone.value = Settings.lhStickDeadzone;
         hid_forwarding.checked = Settings.hidForwarding;
 
         auto_connect_usb.checked = DashboardSettings.auto_connect_usb;

--- a/dashboard/settings.cpp
+++ b/dashboard/settings.cpp
@@ -121,6 +121,7 @@ void Settings::emitAllChanged()
 	openvrChanged();
 	debugGuiChanged();
 	steamVrLhChanged();
+	lhStickDeadzoneChanged();
 	hidForwardingChanged();
 	portChanged();
 	hostnameChanged();
@@ -416,6 +417,22 @@ void Settings::set_steamVrLh(const bool & value)
 		steamVrLhChanged();
 }
 
+float Settings::lhStickDeadzone() const
+{
+	auto it = m_jsonSettings.find("lh-stick-deadzone");
+	if (it != m_jsonSettings.end() and it->is_number())
+		return static_cast<float>(*it);
+	return 0.0f;
+}
+
+void Settings::set_lhStickDeadzone(const float & value)
+{
+	auto old = lhStickDeadzone();
+	m_jsonSettings["lh-stick-deadzone"] = value;
+	if (old != value)
+		lhStickDeadzoneChanged();
+}
+
 bool Settings::tcpOnly() const
 {
 	auto it = m_jsonSettings.find("tcp-only");
@@ -539,6 +556,7 @@ void Settings::restore_defaults()
 	m_jsonSettings.erase("hid-forwarding");
 	m_jsonSettings.erase("debug-gui");
 	m_jsonSettings.erase("use-steamvr-lh");
+	m_jsonSettings.erase("lh-stick-deadzone");
 	m_jsonSettings.erase("tcp-only");
 	m_jsonSettings.erase("application");
 	m_jsonSettings.erase("port");

--- a/dashboard/settings.h
+++ b/dashboard/settings.h
@@ -76,6 +76,7 @@ public:
 	Q_PROPERTY(bool hidForwarding READ hidForwarding WRITE set_hidForwarding NOTIFY hidForwardingChanged)
 	Q_PROPERTY(bool debugGui READ debugGui WRITE set_debugGui NOTIFY debugGuiChanged)
 	Q_PROPERTY(bool steamVrLh READ steamVrLh WRITE set_steamVrLh NOTIFY steamVrLhChanged)
+	Q_PROPERTY(float lhStickDeadzone READ lhStickDeadzone WRITE set_lhStickDeadzone NOTIFY lhStickDeadzoneChanged)
 
 	Q_PROPERTY(bool flatpak READ flatpak CONSTANT)
 	Q_PROPERTY(int default_port READ default_port CONSTANT)
@@ -91,6 +92,7 @@ public:
 	SETTER_GETTER_NOTIFY(bool, hidForwarding)
 	SETTER_GETTER_NOTIFY(bool, debugGui)
 	SETTER_GETTER_NOTIFY(bool, steamVrLh)
+	SETTER_GETTER_NOTIFY(float, lhStickDeadzone)
 	SETTER_GETTER_NOTIFY(bool, tcpOnly)
 	SETTER_GETTER_NOTIFY(int, port)
 	SETTER_GETTER_NOTIFY(QString, hostname)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -159,6 +159,13 @@ Only available when built with `WIVRN_FEATURE_STEAMVR_LIGHTHOUSE`
 
 Enables the driver to load SteamVR Lighthouse devices.
 
+## `lh-stick-deadzone`
+Default value: `0`
+
+Only available when built with `WIVRN_FEATURE_STEAMVR_LIGHTHOUSE`
+
+Applies a deadzone to joysticks on SteamVR controllers (e.g. Index).
+
 ## `port`
 Default value: `9757`
 

--- a/server/driver/configuration.cpp
+++ b/server/driver/configuration.cpp
@@ -200,6 +200,9 @@ configuration::configuration()
 		if (auto it = json.find("use-steamvr-lh"); it != json.end())
 			use_steamvr_lh = *it;
 
+		if (auto it = json.find("lh-stick-deadzone"); it != json.end())
+			lh_stick_deadzone = *it;
+
 		if (auto it = json.find("bit-depth"); it != json.end())
 			bit_depth = *it;
 

--- a/server/driver/configuration.h
+++ b/server/driver/configuration.h
@@ -57,6 +57,7 @@ struct configuration
 	std::vector<std::string> application;
 	bool debug_gui = false;
 	bool use_steamvr_lh = false;
+	std::optional<float> lh_stick_deadzone;
 	bool hid_forwarding = false;
 	bool tcp_only = false;
 	int port = wivrn::default_port;

--- a/server/driver/wivrn_session.cpp
+++ b/server/driver/wivrn_session.cpp
@@ -135,12 +135,18 @@ wivrn::wivrn_session::wivrn_session(std::unique_ptr<wivrn_connection> connection
 	roles.gamepad = static_xdev_count;
 	static_xdevs[static_xdev_count++] = &gamepad_device.emplace(*this);
 
+	auto conf = configuration();
+
 #if WIVRN_FEATURE_STEAMVR_LIGHTHOUSE
-	auto use_steamvr_lh = configuration().use_steamvr_lh || std::getenv("WIVRN_USE_STEAMVR_LH");
+
+	auto use_steamvr_lh = conf.use_steamvr_lh || std::getenv("WIVRN_USE_STEAMVR_LH");
 	xrt_system_devices * lhdevs = NULL;
 
 	if (use_steamvr_lh)
 	{
+		if (conf.lh_stick_deadzone > 0.01f)
+			setenv("LH_STICK_DEADZONE", std::format("{:.2}", *conf.lh_stick_deadzone).c_str(), true);
+
 		U_LOG_W("=====================");
 		U_LOG_W("Disregard lighthousedb / chaperone related error messages from the lighthouse driver. These are irrelevant in case of WiVRn.");
 		U_LOG_W("If getting a SIGSEGV right after this, you are likely using an unsupported SteamVR version!");
@@ -257,7 +263,7 @@ wivrn::wivrn_session::wivrn_session(std::unique_ptr<wivrn_connection> connection
 		strlcpy(xrt_system.base.properties.name, system_name.c_str(), std::size(xrt_system.base.properties.name));
 	}
 
-	if (configuration().hid_forwarding)
+	if (conf.hid_forwarding)
 	{
 		try
 		{


### PR DESCRIPTION
With systemd becoming the norm, it's getting awkward to set arbitrary environment variables.

This adds a slider to the UI and setenv's the deadzone before steamvr_lh is initialized.

<img width="632" height="102" alt="image" src="https://github.com/user-attachments/assets/fe8bb230-04dd-4e37-9e31-f1962f79f40c" />

Tested and works!
