### PR TITLE
Add support for extended refresh rates on Quest 3

### DIFF
--- a/client/hmd_traits.cpp
+++ b/client/hmd_traits.cpp
@@ -26,6 +26,7 @@
 #include <boost/pfr.hpp>
 #include <cassert>
 #include <cctype>
+#include <concepts>
 #include <cstdlib>
 #include <cstring>
 #include <format>
@@ -140,6 +141,42 @@ std::optional<std::unordered_set<std::string>> env(std::string_view name)
 	return std::unordered_set<std::string>{std::from_range, utils::split(*values, ",")};
 }
 
+template <>
+std::optional<std::vector<float>> env(std::string_view name)
+{
+	const auto value = env<std::string>(name);
+	if (not value)
+		return std::nullopt;
+
+	std::vector<float> result;
+	for (const auto & i: utils::split(*value, ","))
+	{
+		try
+		{
+			result.push_back(std::stof(i));
+		}
+		catch (std::exception & e)
+		{
+			spdlog::warn("failed to parse {} (value: {}): {}", name, *value, e.what());
+		}
+	}
+
+	return result;
+}
+
+// A trait field that is a list of values, overridden as a whole
+template <typename T>
+concept trait_container = requires(T & t, const typename T::value_type & v) {
+	typename T::value_type;
+	t.begin();
+	t.end();
+	t.insert(t.end(), v);
+} and (std::same_as<typename T::value_type, std::string> or std::same_as<typename T::value_type, float>);
+
+// Set-like containers support removing values prefixed with '-'
+template <typename T>
+concept trait_set = trait_container<T> and requires(T & t, const typename T::value_type & v) { t.erase(v); };
+
 void hmd_traits::init()
 {
 #ifndef NDEBUG
@@ -170,6 +207,28 @@ void hmd_traits::init()
 		// Quest breaks spec and does not support grip_surface for ext/hand_interaction_ext
 		hand_interaction_grip_surface = false;
 
+		// HorizonOS version, e.g. "2.7.0"
+		std::optional<std::pair<int, int>> hzos_version;
+		if (auto v = get_property("ro.hzos.build.display_name"))
+		{
+			auto digits = utils::split(*v, ".");
+			try
+			{
+				hzos_version = std::pair{std::stoi(digits.at(0)), std::stoi(digits.at(1))};
+			}
+			catch (...)
+			{
+				spdlog::warn("Failed to parse Horizon OS version {}", *v);
+			}
+		}
+
+		auto hzos_at_least = [&hzos_version](int major, int minor) {
+			if (not hzos_version)
+				return false;
+			auto [actual_major, actual_minor] = *hzos_version;
+			return actual_major > major or (actual_major == major and actual_minor >= minor);
+		};
+
 		if (device == "monterey") // Quest 1
 		{
 			panel_width_override = 1440;
@@ -191,6 +250,18 @@ void hmd_traits::init()
 			panel_width_override = 2064; // Quest 3
 			controller_profile = "meta-quest-touch-plus";
 			usb_net = true;
+
+			// The runtime may not report extended refresh rates even though
+			// it accepts them: Quest 3 supports any integer rate from 72 to
+			// 207 Hz with HorizonOS 2.7 and later, up to 240 Hz with display
+			// scaling enabled
+			// https://developers.meta.com/horizon/documentation/native/android/mobile-display-refresh-rate/
+			if (hzos_at_least(2, 7))
+			{
+				extra_refresh_rates = {144, 165, 185, 200, 207};
+				if (get_property("debug.oculus.forceDisplayScaling").value_or("") == "1")
+					extra_refresh_rates.push_back(240);
+			}
 		}
 		else if (device == "panther") // Quest 3S
 		{
@@ -198,20 +269,8 @@ void hmd_traits::init()
 			controller_profile = "meta-quest-touch-plus";
 		}
 
-		if (auto v = get_property("ro.hzos.build.display_name"))
-		{
-			auto digits = utils::split(*v, ".");
-			try
-			{
-				auto major = std::stoi(digits.at(0));
-				auto minor = std::stoi(digits.at(1));
-				usb_net = major > 2 or (major == 2 and minor >= 6);
-			}
-			catch (...)
-			{
-				spdlog::warn("Failed to parse Horizon OS version {}", *v);
-			}
-		}
+		if (hzos_version)
+			usb_net = hzos_at_least(2, 6);
 	}
 
 	else if (model == "Lynx-R1")
@@ -357,16 +416,26 @@ void hmd_traits::init()
 		                }
 	                },
 
-	                [](std::string_view name, std::unordered_set<std::string> & field) {
-		                if (auto val = env<std::unordered_set<std::string>>(name))
+	                [](std::string_view name, trait_container auto & field) {
+		                using field_type = std::remove_cvref_t<decltype(field)>;
+
+		                if (auto val = env<field_type>(name))
 		                {
-			                for (const auto & i: *val)
+			                spdlog::info("\t{} override", name);
+
+			                if constexpr (trait_set<field_type>)
 			                {
-				                if (i.starts_with("-"))
-					                field.erase(i.substr(1));
-				                else
-					                field.insert(i);
+				                // values prefixed with '-' are removed from the set
+				                for (const auto & i: *val)
+				                {
+					                if (i.starts_with("-"))
+						                field.erase(i.substr(1));
+					                else
+						                field.insert(field.end(), i);
+				                }
 			                }
+			                else
+				                field = std::move(*val);
 		                }
 
 		                for (const auto & i: field)

--- a/client/hmd_traits.h
+++ b/client/hmd_traits.h
@@ -27,6 +27,7 @@
 #include <string>
 #include <unordered_set>
 #include <utility>
+#include <vector>
 #include <openxr/openxr.h>
 
 using hmd_permissions = magic_enum::containers::array<feature, const char *>;
@@ -58,6 +59,7 @@ public:
 	bool usb_net = false;
 	std::unordered_map<std::string, std::string> override_shader;
 	std::unordered_set<std::string> blacklisted_extensions;
+	std::vector<float> extra_refresh_rates;
 #ifndef NDEBUG
 	bool initialized_ = false;
 #endif

--- a/client/xr/session.cpp
+++ b/client/xr/session.cpp
@@ -19,6 +19,7 @@
 
 #include "session.h"
 
+#include "application.h"
 #include "details/enumerate.h"
 #include "openxr/openxr.h"
 #include "utils/contains.h"
@@ -285,11 +286,13 @@ float xr::session::get_current_refresh_rate()
 
 std::vector<float> xr::session::get_refresh_rates()
 {
+	std::vector<float> rates;
+
 	if (xrEnumerateDisplayRefreshRatesFB)
 	{
 		try
 		{
-			return xr::details::enumerate<float>(xrEnumerateDisplayRefreshRatesFB, id);
+			rates = xr::details::enumerate<float>(xrEnumerateDisplayRefreshRatesFB, id);
 		}
 		catch (...)
 		{
@@ -297,7 +300,17 @@ std::vector<float> xr::session::get_refresh_rates()
 		}
 	}
 
-	return {};
+	// The runtime may not enumerate all supported rates, add the rates from
+	// hmd_traits, requesting unenumerated values is allowed on supported devices
+	for (float rate: application::get_hmd_traits().extra_refresh_rates)
+	{
+		// the enumerated list is sorted, insert at the sorted position
+		auto pos = std::ranges::lower_bound(rates, rate);
+		if (pos == rates.end() or *pos != rate)
+			rates.insert(pos, rate);
+	}
+
+	return rates;
 }
 
 void xr::session::set_refresh_rate(float refresh_rate)

--- a/server/driver/wivrn_session.cpp
+++ b/server/driver/wivrn_session.cpp
@@ -476,12 +476,25 @@ bool wivrn_session::connected()
 	return connection->is_active();
 }
 
+// In automatic mode, don't start above this rate, refresh_rate_adjuster
+// increases it if the application can sustain it
+static constexpr float max_auto_rate = 120;
+
 float wivrn_session::default_fps()
 {
 	auto s = settings.lock();
 	if (s->preferred_refresh_rate)
 		return s->preferred_refresh_rate / s->fps_divider;
-	return headset_info.available_refresh_rates.back();
+
+	float rate = 0;
+	for (float i: headset_info.available_refresh_rates)
+	{
+		if (i > max_auto_rate)
+			break;
+		rate = i;
+	}
+
+	return rate == 0 ? headset_info.available_refresh_rates.front() : rate;
 }
 
 void wivrn_session::add_tracking_request(device_id device, int64_t at_ns, int64_t produced_ns, int64_t now)


### PR DESCRIPTION
# Add support for extended refresh rates on Quest 3

## Problem

On Quest 3 with HorizonOS 2.7 and later, the display accepts any integer refresh rate from 72 through 207 Hz through `xrRequestDisplayRefreshRateFB` (240 Hz when display scaling is enabled in developer mode), but `xrEnumerateDisplayRefreshRatesFB` still only reports rates up to 120 Hz, so applications have no way to discover the extended rates.

Reference: [Set Display Refresh Rates — Meta Horizon OS docs](https://developers.meta.com/horizon/documentation/native/android/mobile-display-refresh-rate/)

## This change

**Commit 1 — client:**

- **`hmd_traits`**: new per-headset `extra_refresh_rates` field. Quest 3 (`eureka`) gets `144, 165, 185, 200, 207` when the HorizonOS version is at least 2.7, reusing the existing `ro.hzos.build.display_name` detection, plus `240` when `debug.oculus.forceDisplayScaling` is `1` (240 Hz additionally requires the user to set `debug.oculus.refreshRate`). The field participates in the existing `debug.wivrn.*` / `WIVRN_*` override mechanism, so any headset can get extra rates with e.g. `adb shell setprop debug.wivrn.extra_refresh_rates "144,165"`.
- **`xr::session::get_refresh_rates()`**: inserts the extra rates at the sorted position in the enumerated list. This is the single choke point: the in-headset picker, saved-config validation, and `headset_info_packet` all pick the extended rates up automatically, so the server-side auto adjuster and D-Bus see them too. No protocol changes.
- Requesting a rate outside of the enumerated list may fail with `XR_ERROR_DISPLAY_REFRESH_RATE_UNSUPPORTED_FB`, which `set_refresh_rate` already logs.

**Commit 2 — server:**

- In automatic mode, start at the highest available rate not exceeding 120 Hz instead of the highest available rate; `refresh_rate_adjuster` still increases it if the application sustains it. Explicit rate selection is unaffected.

## Testing

- Quest 3 (HorizonOS 2.7, RTX 5070 Ti server, NVENC AV1):
  - 165 Hz: works, noticeably smoother than 120 Hz
  - 207 Hz: runs but shows white-noise artifacts at the top of the image — looks like an encoder/decoder issue at this fps, still investigating (happy to hear ideas)
  - 240 Hz: reachable with the props set (not fully validated yet)
- Non-extended paths (enumerated rates, other headsets) are unchanged: the merge is a no-op when `extra_refresh_rates` is empty.

<details>
<summary>Build verification</summary>

- Server + Linux client build clean with `-Werror` (GCC 16 / Fedora 44)
- Android APK (`assembleRelease`) builds and was tested on device
- `clang-format` clean
</details>

---

<sup>Acknowledgement: this pull request was developed with AI assistance (opencode, GLM). All code was reviewed, built and tested on hardware by the submitter.</sup>
