### PR TITLE
Fix angular velocity sign in pose_list

### DIFF
--- a/server/driver/pose_list.cpp
+++ b/server/driver/pose_list.cpp
@@ -285,7 +285,7 @@ std::pair<XrTime, xrt_space_relation> pose_list::get_at(XrTime at_timestamp_ns)
 			        (*orientation.dy)[1],
 			        (*orientation.dy)[2],
 			        (*orientation.dy)[3]};
-			Eigen::Quaternionf half_ω = dq * q;
+			Eigen::Quaternionf half_ω = dq * q.conjugate();
 
 			flags(XRT_SPACE_RELATION_ANGULAR_VELOCITY_VALID_BIT);
 			ret.angular_velocity = {


### PR DESCRIPTION
The angular velocity was worked out with the wrong formula. It used dq * q, but it should be dq * q^-1 (the inverse of q, which is just its conjugate here because q is normalized).

Using q instead of its inverse pointed the angular velocity the wrong way.

Makes throwing items in Half Life: Alyx feel more natural.