### PR TITLE
Raise the vulkan h265 encoder's minimum coding block to 16x16

### DIFF
--- a/server/encoder/video_encoder_vulkan_h265.cpp
+++ b/server/encoder/video_encoder_vulkan_h265.cpp
@@ -134,7 +134,7 @@ wivrn::video_encoder_vulkan_h265::video_encoder_vulkan_h265(
                 .bit_depth_luma_minus8 = static_cast<uint8_t>(settings.bit_depth - 8),
                 .bit_depth_chroma_minus8 = static_cast<uint8_t>(settings.bit_depth - 8),
                 .log2_max_pic_order_cnt_lsb_minus4 = 4,      // arbitrary
-                .log2_min_luma_coding_block_size_minus3 = 0, // keep it 0, related values are filled in create()
+                .log2_min_luma_coding_block_size_minus3 = 0, // set in create(), with the related values
                 .num_short_term_ref_pic_sets = 0,
                 .num_long_term_ref_pics_sps = 0,
                 .pcm_sample_bit_depth_luma_minus1 = 0,
@@ -309,12 +309,14 @@ std::unique_ptr<wivrn::video_encoder_vulkan_h265> wivrn::video_encoder_vulkan_h2
 		self->rate_control->pNext = &self->rc_h265;
 	}
 
-	self->sps.log2_diff_max_min_luma_coding_block_size = find_msb((uint32_t)encode_h265_caps.ctbSizes) + 1; // First bit is 16x16.
+	const uint32_t log2_ctb_size = find_msb((uint32_t)encode_h265_caps.ctbSizes) + 4;
+	self->sps.log2_min_luma_coding_block_size_minus3 = 1;
+	self->sps.log2_diff_max_min_luma_coding_block_size = log2_ctb_size - 4;
 	self->sps.log2_min_luma_transform_block_size_minus2 = find_lsb((uint32_t)encode_h265_caps.transformBlockSizes);
 	self->sps.log2_diff_max_min_luma_transform_block_size =
 	        find_msb((uint32_t)encode_h265_caps.transformBlockSizes) - find_lsb((uint32_t)encode_h265_caps.transformBlockSizes);
 
-	uint32_t max_transform_hierarchy = (find_msb((uint32_t)encode_h265_caps.ctbSizes) + 4) - (find_lsb((uint32_t)encode_h265_caps.transformBlockSizes) + 2);
+	uint32_t max_transform_hierarchy = log2_ctb_size - (find_lsb((uint32_t)encode_h265_caps.transformBlockSizes) + 2);
 	self->sps.max_transform_hierarchy_depth_inter = max_transform_hierarchy;
 	self->sps.max_transform_hierarchy_depth_intra = max_transform_hierarchy;
 


### PR DESCRIPTION
## Raise the vulkan h265 encoder's minimum coding block to 16x16

When working on a headless profiling solution, I did a test comparing nvenc and Vulkan for h265 and h264. A big performance difference popped out. This PR gets h265 encoding via Vulkan on par with nvenc.


The SPS allowed coding blocks down to 8x8. On NVIDIA that costs 4x the encode time, enough to miss the frame deadline at headset resolution.

Measured on an RTX 3080 Ti, 1920x1472 per eye at 90 Hz, 5 runs x 20 s:

| | `encodeVideoKHR` p50 | sustained fps |
| --- | --- | --- |
| before | 13.423 ms | 36.5 |
| after | **3.175 ms** | **90.1** |
| nvenc h265, same GPU | 4.356 ms | 90.0 |

Encode time is linear in pixel count either way. No other SPS/PPS knob moves it: transform hierarchy depth, transform skip, SAO, AMP, strong intra smoothing, merge candidates, bit depth and encode quality level are all within noise.

h264 is unaffected — fixed 16x16 macroblocks, no minimum CU.

### Reproducing

Needs the benchmark harness from #1094

```bash
tools/perfetto/encoder_bench.py bootstrap
BENCH=~/.cache/wivrn-encoder-bench/bin/encoder_bench.py

$BENCH run --encoder vulkan --codec h265   # before
git cherry-pick <this commit>
$BENCH run --encoder vulkan --codec h265   # after
$BENCH report                              # both, with the delta
```

### Not covered

- Compression efficiency is unmeasured. Dropping the 8x8 partition costs quality at a fixed bitrate; the old configuration was dropping frames instead.
- Tested on NVIDIA only.
