### PR TITLE
app_pacer: add completion headroom for streaming compositors

### DIFF
--- a/server/driver/app_pacer.cpp
+++ b/server/driver/app_pacer.cpp
@@ -133,13 +133,39 @@ void app_pacer::predict(int64_t now_ns,
 	get_frame(frame_id) = {.frame_id = frame_id};
 
 	// no need to lock, called in same thread as writes
-	auto min_ready = now_ns + cpu_time + gpu_time + compositor_time;
+	const int64_t margin_ns = int64_t(U_TIME_1MS_IN_NS * min_margin_ms.val);
+
+	// compositor_time is Monado's extra_ns: the gap from the compositor main loop waking
+	// up to display. The compositor picks this app's frame up ~extra_ns before display,
+	// and the wake-up below (display - (cpu + gpu + compositor_time + margin)) makes the
+	// compositor_time terms cancel, leaving only min_margin (~1.5 ms) of slack between
+	// the app finishing a frame and the compositor picking it up. On a native compositor
+	// extra_ns is vsync-stable and 1.5 ms is enough; on a network-streaming compositor
+	// extra_ns is the pipeline latency (encode + network + decode) and it drifts while a
+	// frame is in flight (phase adjustment, latency re-estimation), routinely eating the
+	// 1.5 ms. The frame then misses its pickup, a stale frame is shown, and the next
+	// completed frame drops the missed one -> periodic flashing/stutter.
+	//
+	// Add up to one display period of completion headroom, phased in only for the part of
+	// extra_ns that exceeds one period. On a native compositor extra_ns <= period, so
+	// safety == 0 and behaviour is unchanged.
+	const int64_t safety = std::clamp<int64_t>(compositor_time - period, int64_t(0), period);
+
+	// Full budget: places the display time (achievability loop below) and the wake-up
+	// lead, and keeps the wake-up time >= now so the app is never left free-running.
+	auto min_ready = now_ns + cpu_time + gpu_time + compositor_time + safety + margin_ns;
+
+	// The "is the app itself too slow to hit its slot" test must not include the pipeline
+	// latency, or it would fire on every streamed frame (extra_ns > period always). Cap
+	// the compositor term at one display period for this test only.
+	auto app_limited_ready = now_ns + cpu_time + gpu_time + std::min<int64_t>(compositor_time, period);
+
 	// The ideal display time: one frame after the last
 	last_display_time += period;
 	// Sync phase with compositor
 	last_display_time = compositor_display_time + period * ((period / 2 + last_display_time - compositor_display_time) / period);
 
-	if (cpu_time > period or gpu_time > period or (min_ready > last_display_time and min_ready < last_display_time + period))
+	if (cpu_time > period or gpu_time > period or (app_limited_ready > last_display_time and app_limited_ready < last_display_time + period))
 	{
 		// We are limited by app time, don't wait
 		*out_wake_up_time = now_ns;
@@ -156,7 +182,7 @@ void app_pacer::predict(int64_t now_ns,
 
 		*out_predicted_display_time = last_display_time;
 		*out_predicted_display_period = period;
-		*out_wake_up_time = last_display_time - (cpu_time + gpu_time + compositor_time + int64_t(U_TIME_1MS_IN_NS * min_margin_ms.val));
+		*out_wake_up_time = last_display_time - (cpu_time + gpu_time + compositor_time + safety + margin_ns);
 	}
 }
 


### PR DESCRIPTION
## Problem

Fixes the periodic flashing/stutter on network-streamed sessions (#873; severe on high-pipeline-latency / NVIDIA encode setups).

The app pacer wakes the app at:

```
wake = display - (cpu_time + gpu_time + compositor_time + min_margin)
```

`compositor_time` is Monado's `extra_ns` (the compositor picks the frame up ~`extra_ns` before display), so the `compositor_time` terms cancel and only `min_margin` (~1.5 ms) of slack is left between the app finishing a frame and the compositor picking it up.

On a **native** compositor `extra_ns` is vsync-stable and 1.5 ms is fine. On a **streaming** compositor `extra_ns` is the full pipeline latency (encode + network + decode, ~50 ms on my Wi-Fi link) and it drifts frame-to-frame (phase adjustment, latency re-estimation), routinely eating the 1.5 ms. The frame then misses its pickup → a stale frame is shown → the next completed frame drops the missed one (`wait_for_scheduled_free`, "Dropping old missed frame") → periodic flash/stutter.

## Fix

Add up to one display period of completion headroom, phased in only for the part of `extra_ns` that exceeds one period:

```
safety = clamp(compositor_time - period, 0, period)
```

- **Native** (`extra_ns <= period`) ⇒ `safety == 0` ⇒ behaviour unchanged, zero risk.
- **Streaming** ⇒ completion margin grows from ~1.5 ms to ~15 ms. The term is added symmetrically to both the `min_ready` display placement and the wake-up lead, so it does **not** add display latency — it only moves the wake-up earlier by the same amount it reserves.

The "is the app itself too slow to hit its slot" test is kept on a separate app-limited estimate that caps `compositor_time` at one period, so it does not false-fire on every streamed frame (where `extra_ns > period` always).

## Evidence (RTX 4050 mobile / Quest 3, 72 Hz Wi-Fi stream)

Raw per-frame pacer log, 14.8k frames:

- `gpu_time` avg **0.12 ms** (never > period), `cpu_time` avg **5.3 ms** — app side is healthy.
- `compositor_time` avg **51 ms** (range 8–82 ms), 99.8% > period — this is the pipeline latency, not app work.

Completion-vs-pickup margin (does the app finish before the compositor's pickup deadline?):

| build | frames finishing **after** pickup deadline (dropped) |
|-------|------|
| stock  | **11.9%** |
| with fix | **0.3%** |

On-head dropped frames: **~7/s → ~1/s** (the remaining ~1/s is app-side stalls, unrelated to pacing). Frame-completion lateness averages **~8 ms** — no added latency.
