### PR TITLE
fix(client): disable vk_debug_ext_allowed on vive focus 3

### DIFF
--- a/client/application.h
+++ b/client/application.h
@@ -335,8 +335,9 @@ public:
 	template <typename T>
 	static void set_debug_reports_name(const T & object, std::string name)
 	{
-		// #ifndef NDEBUG
-		// if (instance().debug_utils_found)
+		if (not vk_allocator::instance().has_debug_utils)
+			return;
+
 		const vk::DebugUtilsObjectNameInfoEXT name_info{
 		        .objectType = T::objectType,
 		        .objectHandle = (uint64_t)(typename T::NativeType)object,
@@ -344,10 +345,6 @@ public:
 		};
 
 		instance().vk_device.setDebugUtilsObjectNameEXT(name_info);
-
-		// printf("set_debug_reports_name %p, %s\n", object, name.c_str());
-		// instance().debug_report_object_name[(uint64_t)object] = std::move(name);
-		// #endif
 	}
 
 	static thread_safe<vk::raii::Queue> & get_queue()

--- a/client/hmd_traits.cpp
+++ b/client/hmd_traits.cpp
@@ -285,7 +285,12 @@ void hmd_traits::init()
 		controller_profile = "htc-vive-focus-3";
 
 		if (model == "VIVE Focus 3")
+		{
 			panel_width_override = 2448;
+
+			// Reports VK_EXT_debug_utils but does not expose vkSetDebugUtilsObjectNameEXT
+			vk_debug_ext_allowed = false;
+		}
 
 		if (model == "VIVE Focus Vision")
 			panel_width_override = 2448;


### PR DESCRIPTION
The Vive runtime for the Focus 3 reports it has debug, but it doesn't. This results in a crash and makes the debug build useless. Add a trait to get debug builds working again on this hardware.